### PR TITLE
Improve robustness of engine termination

### DIFF
--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -171,7 +171,9 @@ class MXNET_API Engine {
   /*!\brief virtual destructor */
   virtual ~Engine() noexcept(false) {}
   /*!
-   * \return Engine singleton.
+   * \return Engine singleton. NULL if Shutdown() is called.
+   *
+   * \note Check nullptr if used in destructors.
    */
   static Engine* Get();
   /*!

--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -180,9 +180,15 @@ class MXNET_API Engine {
    *  This function is called by another singleton X who requires
    *  engine to be destructed after X.
    *
-   * \return A shared pointer to Engine singleton.
+   * \return A ref of the shared pointer to Engine singleton.
    */
-  static std::shared_ptr<Engine> _GetSharedRef();
+  static std::shared_ptr<Engine>& _GetSharedRef();
+
+  /**
+   * \brief Destroy the global engine singleton. Future
+   * access to engine is disabled.
+   */
+  static void Shutdown();
   /*!
    * \brief Push an synchronous operation to the engine.
    * \param exec_fn Execution function that executes the operation.

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -323,13 +323,18 @@ class NDArray {
     }
     /*! \brief destructor */
     ~Chunk() {
+      auto engine_ptr = Engine::Get();
       if (static_data || delay_alloc) {
-        Engine::Get()->DeleteVariable([](RunContext s) {}, shandle.ctx, var);
+        if (engine_ptr) {
+          engine_ptr->DeleteVariable([](RunContext s) {}, shandle.ctx, var);
+        }
       } else {
         Storage::Handle h = this->shandle;
-        Engine::Get()->DeleteVariable([h](RunContext s) {
-            Storage::Get()->Free(h);
-          }, shandle.ctx, var);
+        if (engine_ptr) {
+          Engine::Get()->DeleteVariable([h](RunContext s) {
+              Storage::Get()->Free(h);
+            }, shandle.ctx, var);
+        }
       }
     }
   };

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -115,6 +115,11 @@ class ResourceManager {
    * \return Resource manager singleton.
    */
   static ResourceManager *Get();
+
+  /**
+   * Destroy the Resource manager singleton.
+   */
+  static void Shutdown();
 };
 }  // namespace mxnet
 #endif  // MXNET_RESOURCE_H_

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -107,6 +107,7 @@ int MXRandomSeed(int seed) {
 int MXNotifyShutdown() {
   API_BEGIN();
   Engine::Get()->NotifyShutdown();
+  Engine::Shutdown();
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -107,6 +107,7 @@ int MXRandomSeed(int seed) {
 int MXNotifyShutdown() {
   API_BEGIN();
   Engine::Get()->NotifyShutdown();
+  ResourceManager::Shutdown();
   Engine::Shutdown();
   API_END();
 }

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -43,13 +43,15 @@ inline Engine* CreateEngine() {
 static bool engine_shutdown = false;
 
 std::shared_ptr<Engine>& Engine::_GetSharedRef() {
-  if (engine_shutdown) LOG(FATAL) << "Engine already shutdone" << std::endl;
+  if (engine_shutdown) LOG(FATAL) << "Call GetRef() after engine already shutdown" << std::endl;
   static std::shared_ptr<Engine> sptr(engine::CreateEngine());
   return sptr;
 }
 
 Engine* Engine::Get() {
-  if (engine_shutdown) LOG(FATAL) << "Engine already shutdone" << std::endl;
+  if (engine_shutdown) {
+    return nullptr;
+  }
   static Engine *inst = _GetSharedRef().get();
   return inst;
 }

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -58,6 +58,7 @@ Engine* Engine::Get() {
 
 void Engine::Shutdown() {
   if (!engine_shutdown) {
+    Engine::Get()->WaitForAll();
     _GetSharedRef().reset();
     engine_shutdown = true;
   }

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -39,13 +39,26 @@ inline Engine* CreateEngine() {
 }
 }  // namespace engine
 
-std::shared_ptr<Engine> Engine::_GetSharedRef() {
+
+static bool engine_shutdown = false;
+
+std::shared_ptr<Engine>& Engine::_GetSharedRef() {
+  if (engine_shutdown) LOG(FATAL) << "Engine already shutdone" << std::endl;
   static std::shared_ptr<Engine> sptr(engine::CreateEngine());
   return sptr;
 }
 
 Engine* Engine::Get() {
+  if (engine_shutdown) LOG(FATAL) << "Engine already shutdone" << std::endl;
   static Engine *inst = _GetSharedRef().get();
   return inst;
 }
+
+void Engine::Shutdown() {
+  if (!engine_shutdown) {
+    _GetSharedRef().reset();
+    engine_shutdown = true;
+  }
+}
+
 }  // namespace mxnet

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -38,9 +38,10 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     // create CPU task
     int cpu_priority_nthreads = dmlc::GetEnv("MXNET_CPU_PRIORITY_NTHREADS", 4);
     cpu_priority_worker_.reset(new ThreadWorkerBlock<kPriorityQueue>());
+    auto blockptr = cpu_priority_worker_.get();
     cpu_priority_worker_->pool.reset(new ThreadPool(
-        cpu_priority_nthreads, [this] {
-          this->CPUWorker(cpu_priority_worker_.get());
+        cpu_priority_nthreads, [this, blockptr] {
+          this->CPUWorker(blockptr);
         }));
     // GPU tasks will be created lazily
   }

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -190,8 +190,22 @@ class ResourceManagerImpl : public ResourceManager {
 };
 }  // namespace resource
 
+static resource::ResourceManagerImpl* instance_ptr = nullptr;
+static bool rm_shutdown = false;
+
 ResourceManager* ResourceManager::Get() {
-  static resource::ResourceManagerImpl inst;
-  return &inst;
+  if (instance_ptr == nullptr) {
+    if (rm_shutdown) LOG(FATAL) << "Resource manager already shutdone" << std::endl;
+    instance_ptr = new resource::ResourceManagerImpl();
+  }
+  return instance_ptr;
+}
+
+void ResourceManager::Shutdown() {
+  if (instance_ptr != nullptr) {
+    delete instance_ptr;
+    instance_ptr = nullptr;
+    rm_shutdown = true;
+  }
 }
 }  // namespace mxnet

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -261,10 +261,13 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
 }
 
 GraphExecutor::~GraphExecutor() {
-  Engine::Get()->WaitForAll();
-  // need to delete the operators before delete the NDArray they referenced.
-  for (OpNode& node : op_nodes_) {
-    node.DeleteOperator();
+  auto engine_ptr = Engine::Get();
+  if (engine_ptr) { 
+    engine_ptr->WaitForAll();
+    // need to delete the operators before delete the NDArray they referenced.
+    for (OpNode& node : op_nodes_) {
+      node.DeleteOperator();
+    }
   }
 }
 


### PR DESCRIPTION
Change the "NotifyShutdown" to explicitly destroy the global engine
object.

Previously, the global engine object destruction relies
on the automatic static variable destruction on termination.

Destroying the engine involves a sequence of complicated operations,
including locking and thread joins. Such operations are not safe
to perform during dll unload, especially on windows.

Also fix a bug in threaded_engine_perdevice where the CPUWorker
could segfault by taking null pointer. This happens when
the engine is created and destroyed immediately. The destructor
resets the threadblock shared_ptr to nullptr, and the CPU worker function
is capturing the shared_ptr rather than the real pointer.
