### PR TITLE
Static link libstdc++ on linux

### DIFF
--- a/configure
+++ b/configure
@@ -244,7 +244,7 @@ if [[ $OSTYPE == linux* ]]; then
         USE_OPENMP=1
         WIN32=0
         USE_BLAS="blas"
-        SHARED_LINKER_FLAGS="-Wl,-rpath,\\\$\$ORIGIN -Wl,-rpath,${PWD}/deps/local/lib64 -Wl,-rpath,${PWD}/deps/local/lib"
+        SHARED_LINKER_FLAGS="-Wl,-rpath,\\\$\$ORIGIN -Wl,-rpath,${PWD}/deps/local/lib64 -Wl,-rpath,${PWD}/deps/local/lib -static-libstdc++"
 elif [[ $OSTYPE == darwin* ]]; then
         USE_OPENMP=0
         WIN32=0


### PR DESCRIPTION
Link libstdc++ statically on linux fix
the inconsistent binding of _ZNSs4_Rep20_S_empty_rep_storageE

Fix https://github.com/dato-code/documents/issues/3545
