### PR TITLE
Add pretrained_model and bug fix for extract_feature

### DIFF
--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -51,4 +51,6 @@ from . import module as mod
 from . import module
 from . import module as mod
 
+from . import pretrained_model
+
 __version__ = base.__version__

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -698,7 +698,7 @@ class SFrameImageIter(SFrameIter):
             else:
                 raise ValueError('Shape mismatch. mean_nd has different shape from input image')
         else:
-            raise TypeError('mean_nd must be type np.ndarray or mxnet.ndarray.array')
+            raise TypeError('mean_nd must be type np.ndarray')
         self._rgb_mask = array(self._rgb_mask)
 
         # Rescale parameters

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -1018,7 +1018,7 @@ def extract_feature(model, data, top_layer=None, **kwargs):
 
     """
     fea_sym = get_feature_symbol(model, top_layer)
-    mdl = FeedForward(symbol=fea_sym,
+    mdl = FeedForward(symbol=fea_sym, ctx=model.ctx,
                       arg_params=model.arg_params,
                       aux_params=model.aux_params,
                       allow_extra_params=True,

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -225,6 +225,10 @@ class ImageClassifier(object):
         self.rescale = metadata['scale']
         self._name = metadata['name']
         self._version = metadata['version']
+	if 'label_name' in metadata:
+	    self._label_name = metadata['label_name']
+	else:
+	    self._label_name = 'softmax_label'
 
     @property
     def model(self):
@@ -292,6 +296,8 @@ class ImageClassifier(object):
                                        mean_g=self.mean_rgb[1],
                                        mean_b=self.mean_rgb[2],
                                        mean_nd=self.mean_nd,
+				       data_name='data',
+				       label_name='prob_label',
                                        scale=self.rescale)
         return dataiter
 

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -343,7 +343,7 @@ class ImageClassifier(object):
         ----------
         data : SFrame, SArray[Image] or Image
             SFrame with a single image typed column, an SArray of Images, or
-            a single Image
+            a single Image. The images can be of various sizes. 
        batch_size : int, optional
             batch size of the input to the internal model. Larger
             batch size makes the prediction faster but requires more memory.
@@ -381,7 +381,7 @@ class ImageClassifier(object):
         ----------
         data : SFrame or SArray[Image]
             SFrame with a single image typed column, an SArray of Images.
-            or a single Image.
+            or a single Image. The images can be of various sizes. 
         k : int, optional
             Number of classes returned for each input
         batch_size : int, optional
@@ -610,7 +610,7 @@ class ImageDetector(object):
             Threshold for filtering.
             If the classification score is below threshold, the result will be filtered out
         nms_threshold: float, optional
-            Threshold for filtering by nms(non-maximum surprised)
+            Threshold for filtering by nms(non-maximum suppression)
             If the nms score is below threshold, the result will be filtered out
 
         Returns
@@ -647,23 +647,23 @@ class ImageDetector(object):
     def extract_features(self, data,
                         class_score_threshold=0.5,
                         nms_threshold=0.3,
-                        feature_op="roi_pool5"):
+                        layer="roi_pool5"):
         """
         Detect objects and extract feature of objects for the given data
 
         Parameters
         ----------
         data : SFrame, SArray[Image] or gl.Image
-            SFrame, SArray of images type of a single gl.Imgae
+            SFrame, SArray of images type of a single gl.Image
             Image can be of various sizes. 
         class_score_threshold: float, optional
             Threshold for filtering.
             If the classification score is below threshold, the result will be filtered out
         nms_threshold: float, optional
-            Threshold for filtering by nms(non-maximum suppressed)
+            Threshold for filtering by nms(non-maximum suppression)
             If the nms score is below threshold, the result will be filtered out
-        feature_op: str, optional
-            Name of operator which generates object feature
+        layer: str, optional
+            Name of layer which generates object feature
 
 
         Returns
@@ -675,7 +675,7 @@ class ImageDetector(object):
         if not self._executor_with_feature:
             outputs = self._sym.list_outputs()
             internals = self._sym.get_internals()
-            roi_pool = internals["%s_output" % feature_op]
+            roi_pool = internals["%s_output" % layer]
             fea_pool = _sym.Pooling(name="roi_avg_pool", data=roi_pool,
                                       kernel=(7,7), stride=(1,1), pool_type="avg")
             fea_flatten = _sym.Flatten(name="feature", data=fea_pool)
@@ -695,7 +695,7 @@ class ImageDetector(object):
         Parameters
         ----------
         gl_im: gl.Image
-            The image will be visualized
+            The image to be visualized
         dets: SFrame
             detection result in sframe
 

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -79,7 +79,8 @@ def download_model(url, location=DEFAULT_MODEL_LOCATION, overwrite=False):
     Parameters
     ----------
     url : str,
-      URL of the model. Get the list of available models from https://s3.amazonaws.com/dato-models/mxnet_models/release/
+      URL of the model. Get the list of available models from
+      https://dato.com/products/create/docs/graphlab.mxnet.pretrained_image_model.html
     location : str, optional
       The local directory where the model is saved to.
     overwrite : bool, optional
@@ -636,7 +637,14 @@ class ImageDetector(object):
         else:
             raise Exception("Unsupported input data type.")
 
-    def extract_feature(self, data,
+    def extract_feature(self, *args, **kwargs):
+        """
+        Alias for :py:func:`~mxnet.pretrained_model.ImageDetector.extract_features`
+        """
+        return self.extract_features(*args, **kwargs)
+
+
+    def extract_features(self, data,
                         class_score_threshold=0.5,
                         nms_threshold=0.3,
                         feature_op="roi_pool5"):

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -602,8 +602,8 @@ class ImageDetector(object):
 
         Parameters
         ----------
-        data : SArray[Image] or gl.Image
-            SArray of images type or a single gl.Imgae
+        data : SFrame, SArray[Image] or gl.Image
+            SFrame, SArray of images type or a single gl.Imgae
             Image can be in various of size
         class_score_threshold: float, optional
             Threshold for filtering.
@@ -645,14 +645,14 @@ class ImageDetector(object):
 
         Parameters
         ----------
-        data : SArray[Image] or gl.Image
-            SArray of images type of a single gl.Imgae
+        data : SFrame, SArray[Image] or gl.Image
+            SFrame, SArray of images type of a single gl.Imgae
             Image can be in various of size
         class_score_threshold: float, optional
             Threshold for filtering.
             If the classification score is below threshold, the result will be filtered out
         nms_threshold: float, optional
-            Threshold for filtering by nms(non-maximum surprised)
+            Threshold for filtering by nms(non-maximum suppressed)
             If the nms score is below threshold, the result will be filtered out
         feature_op: str, optional
             Name of operator which generates object feature
@@ -687,7 +687,7 @@ class ImageDetector(object):
         Parameters
         ----------
         gl_im: gl.Image
-            The image will be visalized
+            The image will be visualized
         dets: SFrame
             detection result in sframe
 

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -1,0 +1,363 @@
+import os as _os
+import logging as _logging
+import json as _json
+from collections import namedtuple as _namedtuple
+from .model import FeedForward as _FeedForward
+from .model import extract_feature as _extract_feature 
+from . import ndarray as _ndarray
+from . import io as _io
+import numpy as _np
+import requests
+
+_LOGGER = _logging.getLogger(__name__)
+
+class ModelTypeEnum(object):
+    """
+    Enumeration of Pretrained Model Type
+    """
+    IMAGE_CLASSIFIER= 'IMAGE_CLASSIFIER'
+
+ModelEntry = _namedtuple('ModelEntry', ['name', 'type', 'version'])
+
+
+"""
+Default location for model download
+"""
+DEFAULT_MODEL_LOCATION=_os.path.expanduser('~/.graphlab/mxnet_models')
+
+
+def list_models(location=DEFAULT_MODEL_LOCATION):
+    """
+    Return list of pretrained model names.
+
+    Parameters
+    ----------
+    location : str, optional
+      The local directory where the model is saved to.
+
+    Examples
+    --------
+    >>> mx.pretrained_model.list_models()
+    """
+    if not _os.path.exists(location):
+        _os.makedirs(location)
+
+    models = [p for p in _os.listdir(location)]
+    ret = []
+    for name in models:
+        model_path = _os.path.join(location, name)
+        if not _os.path.isdir(model_path):
+            continue
+        metadata_path = _os.path.join(model_path, 'metadata.json')
+        version = None
+        try:
+            f = open(metadata_path)
+            metadata = _json.load(f)
+            version = metadata['version']
+            model_type = metadata['model_type']
+            name = metadata['name']
+            ret.append(ModelEntry(name, model_type, version))
+        except Exception as e:
+            _LOGGER.warn('Unable to open or parse model metadata %s.' % metadata_path)
+    return ret
+
+def _download_file(url, target_file):
+    r = requests.get(url, stream=True)
+    with open(target_file, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=1024 * 1024):
+            if chunk:
+                f.write(chunk)
+
+def download_model(url, location=DEFAULT_MODEL_LOCATION, overwrite=False):
+    """
+    Perform downloading the model to local filesystem.
+
+    Parameters
+    ----------
+    url : str,
+      URL of the model. Get the list of available models from https://github.com/dato-code/mxnet.
+    location : str, optional
+      The local directory where the model is saved to.
+    overwrite : bool, optional
+      If true, remove existing models first.
+
+    Examples
+    --------
+    >>> mx.pretrained_model.download_model('https://.../InceptionV3.tar.gz')
+    >>> model = mx.pretrained_model.load_model('InceptionV3')
+    """
+    name = url.split('/')[-1]
+    name = name.split('-')[0]
+    target_dir = _os.path.join(location, name)
+    target_exists = _os.path.exists(target_dir)
+    if overwrite is False and target_exists:
+        raise OSError("Target directory %s already exists. Please remove existing model or set overwrite to True" % target_dir)
+    # Peform download
+    _LOGGER.info("Begin downloading %s" % (url))
+    import tempfile
+    import hashlib
+    import shutil
+    import tarfile
+    import sys
+
+    f = tempfile.NamedTemporaryFile(suffix='tar.gz')
+    _download_file(url, f.name)
+    _LOGGER.info("Filed downloaded to %s" % (f.name))
+
+    # Extract
+    if target_exists:
+        _LOGGER.info("Remove existing model: %s" % target_dir)
+        shutil.rmtree(target_dir)
+    _os.makedirs(target_dir)
+    _LOGGER.info("Extracting model to %s" % target_dir)
+    tar = tarfile.open(f.name)
+    tar.extractall(location)
+    tar.close()
+    _LOGGER.info("Model %s is downloaded to %s" % (name, target_dir))
+
+
+def load_model(name, ctx=None, location=DEFAULT_MODEL_LOCATION):
+    """
+    Load a pretrained model by name.
+
+    Parameters
+    ----------
+    name : str
+        Name of the pretrained model. Model must be downloaded first
+    ctx : mx.context, optional
+        Context of the model. Default None is equivalent to mx.cpu()
+    location : str, optional
+        The directory which contains downloaded models
+
+    Examples
+    --------
+    >>> model = mx.pretrained_model.load_model('InceptionV3', ctx=mx.gpu(0))
+    """
+    if not any(name == m.name for m in list_models(location)):
+        raise KeyError('Model %s does not exist. Models can be listed using list_models()' % name)
+    target_dir = _os.path.join(location, name)
+    return load_path(target_dir, ctx)
+
+
+def load_path(target_dir, ctx=None):
+    """
+    Load a pretrained model by path.
+
+    Parameters
+    ----------
+    path : str
+        Path of the downloaded pretrained model.
+    ctx : mx.context, optional
+        Context of the model. Default None is equivalent to mx.cpu().
+    location : str, optional
+        The directory which contains downloaded pretrained models
+
+    Examples
+    --------
+    >>> model = mx.pretrained_model.load_model('~/.graphlab/mxnet_models/InceptionV3')
+    """
+
+    _LOGGER.debug('load from: %s' % (target_dir))
+    target_dir = _os.path.expanduser(target_dir)
+
+    # Load the model metadata
+    metadata_path = _os.path.join(target_dir, 'metadata.json')
+    _LOGGER.debug('metadata_path: %s' % metadata_path)
+    metadata = _json.load(open(metadata_path))
+    _LOGGER.debug('metadata: %s' % str(metadata))
+    if metadata['mean_nd'] is not None:
+        mean_nd_path = _os.path.join(target_dir, metadata['mean_nd'])
+        mean_nd = _ndarray.load(mean_nd_path)['mean_img'].asnumpy()
+        # mean_nd is in c, h, w order. need to convert to h, w, c
+        mean_nd = _np.swapaxes(mean_nd, 0, 2) # c, h, w -> w, h, c
+        mean_nd = _np.swapaxes(mean_nd, 0, 1) # w, h, c -> h, w, c
+        metadata['mean_nd'] = mean_nd
+
+    # Load Image Classifier
+    if metadata['model_type'] == ModelTypeEnum.IMAGE_CLASSIFIER:
+        param_file = [f for f in _os.listdir(target_dir) if f.endswith('.params')]
+        if len(param_file) != 1:
+            raise ValueError('Invalid model directory %s. Please remove the directory and redownload the model' % target_dir)
+
+        # Parse the file name to get prefix and epoch
+        _LOGGER.debug('param_file: %s' % param_file[0])
+        prefix = _os.path.splitext(param_file[0])[0]
+        epoch = prefix.split('-')[-1]
+        prefix = prefix[:-(len(epoch) + 1)]
+        prefix = _os.path.join(target_dir, prefix)
+        epoch = int(epoch)
+        _LOGGER.debug('prefix: %s, epoch: %s' % (prefix, epoch))
+
+        # Load the feedforward model
+        model = _FeedForward.load(prefix, epoch, ctx)
+
+        # Load the labels
+        label_file = _os.path.join(target_dir, 'labels.json')
+        _LOGGER.debug('label_file: %s' % label_file)
+        labels = _json.load(open(label_file))
+        return ImageClassifier(model, labels, metadata)
+    else:
+        raise TypeError('Unexpected model type: %s', metadata['model_type'])
+
+
+class ImageClassifier(object):
+    """
+    Wrapper of pretrained image classifier model.
+    
+    Use :py:func:`load_model` or :py:func:`load_path` to load the model. Do not
+    construct directly.
+
+    Parameters
+    ----------
+    model :  FeedForward
+        The underlying model 
+    labels : list
+        Map from index to label
+    metadata : dict
+        Metadata of the model including name, version, input shape, etc.
+    """
+    def __init__(self, model, labels, metadata):
+        self._model = model 
+        self._labels = labels
+        self._input_shape = metadata['input_shape']
+        self.mean_nd = metadata['mean_nd']
+        self.mean_rgb = metadata['mean_rgb']
+        self.rescale = metadata['scale']
+        self._name = metadata['name']
+        self._version = metadata['version']
+
+    @property
+    def model(self):
+        return self._model
+
+    @property
+    def labels(self):
+        return self._labels
+
+    @property
+    def input_shape(self):
+        return self._input_shape
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def version(self):
+        return self._version
+
+    def __str__(self):
+        return "ImageClassifier: " + self._name + "(version %s)" % self._version
+
+    def __repr__(self):
+        return self.__str__()
+
+    def _make_dataiter(self, data, batch_size):
+        try:
+            import graphlab as _gl
+        except ImportError:
+            import sframe as _gl
+        except ImportError:
+            raise ImportError('Require GraphLab Create or SFrame')
+
+        if type(data) is not _gl.SFrame and type(data) is not _gl.SArray:
+            raise TypeError('Input data must be SFrame or SArray')
+        if type(data) is _gl.SArray and data.dtype() != _gl.Image:
+            raise TypeError('Expect image typed SArray, actual type is %s' % str(data.dtype()))
+        elif type(data) is _gl.SFrame:
+            if len(data.column_names()) != 1 or data.column_types()[0] != _gl.Image:
+                raise TypeError('Input SFrame must contain only a single image typed column')
+        if batch_size < len(data):
+            batch_size = len(data)
+
+        if type(data) is _gl.SArray:
+            data = _gl.SFrame({'image': data})
+        image_col = data.column_names()[0]
+        first_image = data[image_col][0]
+        input_shape = (first_image.height, first_image.width, first_image.channels)
+
+        if input_shape != tuple(self.input_shape):
+            _LOGGER.info('Detect image shape mismatches network input shape. Perform resize to shape %s' \
+                    % str(tuple(self.input_shape)))
+            data_resize = _gl.SFrame()
+            data_resize[image_col] = _gl.image_analysis.resize(data[image_col],
+                                                               self.input_shape[0],
+                                                               self.input_shape[1],
+                                                               self.input_shape[2], decode=True)
+            data = data_resize
+
+        dataiter = _io.SFrameImageIter(data, data_field=[image_col],
+                                       batch_size=batch_size,
+                                       mean_r=self.mean_rgb[0],
+                                       mean_g=self.mean_rgb[1],
+                                       mean_b=self.mean_rgb[2],
+                                       mean_nd=self.mean_nd,
+                                       scale=self.rescale)
+        return dataiter
+
+
+    def extract_feature(self, data, batch_size=50):
+        # Make DataIter 
+        dataiter = self._make_dataiter(data, batch_size)
+        return _extract_feature(self.model, dataiter)
+
+
+    def predict_topk(self, data, k=5, batch_size=50):
+        """
+        Predict the topk classes for given data 
+
+        Parameters
+        ----------
+        data : SFrame or SArray[Image]
+            SFrame of a single image typed column.
+            Images must have the same size as the model's input shape.
+        k : int, optional
+            Number of classes returned for each input
+        batch_size : int, optional
+            batch size of the input to the internal model. Larger
+            batch size makes the prediction faster but requires more memory.
+
+        Returns
+        -------
+        out : SFrame
+            An SFrame of 5 columns: row_id, label_id, label, score, rank 
+        
+        Examples
+        --------
+        >>> m = mx.pretrained_model.load_model('MNIST_Conv')
+        >>> sf = SFrame('http://s3.amazonaws.com/dato-datasets/mnist/sframe/train')
+        >>> m.predict_topk(sf['image'])
+        """
+        try:
+            import graphlab as _gl
+        except ImportError:
+            import sframe as _gl
+        except ImportError:
+            raise ImportError('Require GraphLab Create or SFrame')
+
+        # Check input
+        if k > len(self.labels):
+            k = len(self.labels)
+
+        # Make DataIter 
+        dataiter = self._make_dataiter(data, batch_size)
+
+        # Make prediction
+        # pred[i][j] is the score of row i belongs to label j 
+        pred = self.model.predict(dataiter) 
+        # top_idx[i][k] is the label index of kth highest score of row i
+        top_idx = pred.argsort()[:,-k:][:,::-1]
+        # Take row wise index, to get topk score for each row
+        top_scores = pred[_np.arange(pred.shape[0])[:,None], top_idx]
+
+        top_labels = [self.labels[i] for i in top_idx.flatten()]
+        row_ids = _np.repeat(_np.arange(len(pred)), k)
+        ranks = _np.tile(_np.arange(1, k+1), len(pred))
+        
+        ret = _gl.SFrame()
+        ret['row_id'] = row_ids
+        ret['label_id'] = top_idx.flatten()
+        ret['label'] = top_labels
+        ret['score'] = top_scores.flatten()
+        ret['rank'] = ranks
+        return ret

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -604,8 +604,8 @@ class ImageDetector(object):
         Parameters
         ----------
         data : SFrame, SArray[Image] or gl.Image
-            SFrame, SArray of images type or a single gl.Imgae
-            Image can be in various of size
+            SFrame, SArray of images type or a single gl.Image
+            Image can be of various sizes.
         class_score_threshold: float, optional
             Threshold for filtering.
             If the classification score is below threshold, the result will be filtered out
@@ -655,7 +655,7 @@ class ImageDetector(object):
         ----------
         data : SFrame, SArray[Image] or gl.Image
             SFrame, SArray of images type of a single gl.Imgae
-            Image can be in various of size
+            Image can be of various sizes. 
         class_score_threshold: float, optional
             Threshold for filtering.
             If the classification score is below threshold, the result will be filtered out

--- a/python/mxnet/pretrained_model.py
+++ b/python/mxnet/pretrained_model.py
@@ -3,7 +3,7 @@ import logging as _logging
 import json as _json
 from collections import namedtuple as _namedtuple
 from .model import FeedForward as _FeedForward
-from .model import extract_feature as _extract_feature 
+from .model import extract_feature as _extract_feature
 from . import ndarray as _ndarray
 from . import io as _io
 import numpy as _np
@@ -203,21 +203,21 @@ def load_path(target_dir, ctx=None):
 class ImageClassifier(object):
     """
     Wrapper of pretrained image classifier model.
-    
+
     Use :py:func:`load_model` or :py:func:`load_path` to load the model. Do not
     construct directly.
 
     Parameters
     ----------
     model :  FeedForward
-        The underlying model 
+        The underlying model
     labels : list
         Map from index to label
     metadata : dict
         Metadata of the model including name, version, input shape, etc.
     """
     def __init__(self, model, labels, metadata):
-        self._model = model 
+        self._model = model
         self._labels = labels
         self._input_shape = metadata['input_shape']
         self.mean_nd = metadata['mean_nd']
@@ -297,14 +297,14 @@ class ImageClassifier(object):
 
 
     def extract_feature(self, data, batch_size=50):
-        # Make DataIter 
+        # Make DataIter
         dataiter = self._make_dataiter(data, batch_size)
         return _extract_feature(self.model, dataiter)
 
 
     def predict_topk(self, data, k=5, batch_size=50):
         """
-        Predict the topk classes for given data 
+        Predict the topk classes for given data
 
         Parameters
         ----------
@@ -320,8 +320,8 @@ class ImageClassifier(object):
         Returns
         -------
         out : SFrame
-            An SFrame of 5 columns: row_id, label_id, label, score, rank 
-        
+            An SFrame of 5 columns: row_id, label_id, label, score, rank
+
         Examples
         --------
         >>> m = mx.pretrained_model.load_model('MNIST_Conv')
@@ -339,12 +339,12 @@ class ImageClassifier(object):
         if k > len(self.labels):
             k = len(self.labels)
 
-        # Make DataIter 
+        # Make DataIter
         dataiter = self._make_dataiter(data, batch_size)
 
         # Make prediction
-        # pred[i][j] is the score of row i belongs to label j 
-        pred = self.model.predict(dataiter) 
+        # pred[i][j] is the score of row i belongs to label j
+        pred = self.model.predict(dataiter)
         # top_idx[i][k] is the label index of kth highest score of row i
         top_idx = pred.argsort()[:,-k:][:,::-1]
         # Take row wise index, to get topk score for each row
@@ -353,7 +353,7 @@ class ImageClassifier(object):
         top_labels = [self.labels[i] for i in top_idx.flatten()]
         row_ids = _np.repeat(_np.arange(len(pred)), k)
         ranks = _np.tile(_np.arange(1, k+1), len(pred))
-        
+
         ret = _gl.SFrame()
         ret['row_id'] = row_ids
         ret['label_id'] = top_idx.flatten()

--- a/python/mxnet/utils/proposal.py
+++ b/python/mxnet/utils/proposal.py
@@ -1,0 +1,193 @@
+"""
+Proposal Operator transform anchor coordinates into ROI coordinates with prediction results on
+classification probability and bounding box prediction results, and image size and scale information.
+"""
+
+import mxnet as mx
+import numpy as np
+import numpy.random as npr
+
+from rcnn_utils import generate_anchors
+from rcnn_utils import bbox_pred, clip_boxes
+from rcnn_utils import nms
+
+DEBUG = False
+
+
+class ProposalOperator(mx.operator.CustomOp):
+    def __init__(self, feat_stride, scales, is_train=False, output_score=False):
+        super(ProposalOperator, self).__init__()
+        self._feat_stride = float(feat_stride)
+        self._scales = np.fromstring(scales[1:-1], dtype=float, sep=',')
+        self._anchors = generate_anchors(scales=self._scales)
+        self._num_anchors = self._anchors.shape[0]
+        self._output_score = output_score
+
+        if DEBUG:
+            print 'feat_stride: {}'.format(self._feat_stride)
+            print 'anchors:'
+            print self._anchors
+
+    def forward(self, is_train, req, in_data, out_data, aux):
+        # for each (H, W) location i
+        #   generate A anchor boxes centered on cell i
+        #   apply predicted bbox deltas at cell i to each of the A anchors
+        # clip predicted boxes to image
+        # remove predicted boxes with either height or width < threshold
+        # sort all (proposal, score) pairs by score from highest to lowest
+        # take top pre_nms_topN proposals before NMS
+        # apply NMS with threshold 0.7 to remaining proposals
+        # take after_nms_topN proposals after NMS
+        # return the top proposals (-> RoIs top, scores top)
+
+        pre_nms_topN = 6000
+        post_nms_topN = 300
+        nms_thresh = 0.7
+        min_size = 16
+
+        # the first set of anchors are background probabilities
+        # keep the second part
+        scores = in_data[0].asnumpy()[:, self._num_anchors:, :, :]
+        bbox_deltas = in_data[1].asnumpy()
+        im_info = in_data[2].asnumpy()[0, :]
+
+        if DEBUG:
+            print 'im_size: ({}, {})'.format(im_info[0], im_info[1])
+            print 'scale: {}'.format(im_info[2])
+
+        # 1. Generate proposals from bbox_deltas and shifted anchors
+        height, width = scores.shape[-2:]
+
+        if DEBUG:
+            print 'score map size: {}'.format(scores.shape)
+
+        # Enumerate all shifts
+        shift_x = np.arange(0, width) * self._feat_stride
+        shift_y = np.arange(0, height) * self._feat_stride
+        shift_x, shift_y = np.meshgrid(shift_x, shift_y)
+        shifts = np.vstack((shift_x.ravel(), shift_y.ravel(), shift_x.ravel(), shift_y.ravel())).transpose()
+
+        # Enumerate all shifted anchors:
+        #
+        # add A anchors (1, A, 4) to
+        # cell K shifts (K, 1, 4) to get
+        # shift anchors (K, A, 4)
+        # reshape to (K*A, 4) shifted anchors
+        A = self._num_anchors
+        K = shifts.shape[0]
+        anchors = self._anchors.reshape((1, A, 4)) + shifts.reshape((1, K, 4)).transpose((1, 0, 2))
+        anchors = anchors.reshape((K * A, 4))
+
+        # Transpose and reshape predicted bbox transformations to get them
+        # into the same order as the anchors:
+        #
+        # bbox deltas will be (1, 4 * A, H, W) format
+        # transpose to (1, H, W, 4 * A)
+        # reshape to (1 * H * W * A, 4) where rows are ordered by (h, w, a)
+        # in slowest to fastest order
+        bbox_deltas = bbox_deltas.transpose((0, 2, 3, 1)).reshape((-1, 4))
+
+        # Same story for the scores:
+        #
+        # scores are (1, A, H, W) format
+        # transpose to (1, H, W, A)
+        # reshape to (1 * H * W * A, 1) where rows are ordered by (h, w, a)
+        scores = scores.transpose((0, 2, 3, 1)).reshape((-1, 1))
+
+        # Convert anchors into proposals via bbox transformations
+        proposals = bbox_pred(anchors, bbox_deltas)
+
+        # 2. clip predicted boxes to image
+        proposals = clip_boxes(proposals, im_info[:2])
+
+        # 3. remove predicted boxes with either height or width < threshold
+        # (NOTE: convert min_size to input image scale stored in im_info[2])
+        keep = ProposalOperator._filter_boxes(proposals, min_size * im_info[2])
+        proposals = proposals[keep, :]
+        scores = scores[keep]
+
+        # 4. sort all (proposal, score) pairs by score from highest to lowest
+        # 5. take top pre_nms_topN (e.g. 6000)
+        order = scores.ravel().argsort()[::-1]
+        if pre_nms_topN > 0:
+            order = order[:pre_nms_topN]
+        proposals = proposals[order, :]
+        scores = scores[order]
+
+        # 6. apply nms (e.g. threshold = 0.7)
+        # 7. take after_nms_topN (e.g. 300)
+        # 8. return the top proposals (-> RoIs top)
+        keep = nms(np.hstack((proposals, scores)), nms_thresh)
+        if post_nms_topN > 0:
+            keep = keep[:post_nms_topN]
+        # pad to ensure output size remains unchanged
+        if len(keep) < post_nms_topN:
+            pad = npr.choice(keep, size=post_nms_topN - len(keep))
+            keep = np.hstack((keep, pad))
+        proposals = proposals[keep, :]
+        scores = scores[keep]
+
+        # Output rois array
+        # Our RPN implementation only supports a single input image, so all
+        # batch inds are 0
+        batch_inds = np.zeros((proposals.shape[0], 1), dtype=np.float32)
+        blob = np.hstack((batch_inds, proposals.astype(np.float32, copy=False)))
+        self.assign(out_data[0], req[0], blob)
+
+        if self._output_score:
+            self.assign(out_data[1], req[1], scores.astype(np.float32, copy=False))
+
+    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+        pass
+
+    @staticmethod
+    def _filter_boxes(boxes, min_size):
+        """ Remove all boxes with any side smaller than min_size """
+        ws = boxes[:, 2] - boxes[:, 0] + 1
+        hs = boxes[:, 3] - boxes[:, 1] + 1
+        keep = np.where((ws >= min_size) & (hs >= min_size))[0]
+        return keep
+
+
+@mx.operator.register("proposal")
+class ProposalProp(mx.operator.CustomOpProp):
+    def __init__(self, feat_stride, scales, is_train=False, output_score=False):
+        super(ProposalProp, self).__init__(need_top_grad=False)
+        self._feat_stride = feat_stride
+        self._scales = scales
+        self._is_train = is_train
+        self._output_score = output_score
+
+
+    def list_arguments(self):
+        return ['cls_prob', 'bbox_pred', 'im_info']
+
+    def list_outputs(self):
+        if self._output_score:
+            return ['output', 'score']
+        else:
+            return ['output']
+
+    def infer_shape(self, in_shape):
+        cls_prob_shape = in_shape[0]
+        bbox_pred_shape = in_shape[1]
+        assert cls_prob_shape[0] == bbox_pred_shape[0], 'ROI number does not equal in cls and reg'
+
+        batch_size = cls_prob_shape[0]
+        if batch_size > 1:
+            raise ValueError("Only single item batches are supported")
+
+        im_info_shape = (batch_size, 3)
+        output_shape = (300, 5)
+        score_shape = (300, 1)
+
+        if self._output_score:
+            return [cls_prob_shape, bbox_pred_shape, im_info_shape], [output_shape, score_shape]
+        else:
+            return [cls_prob_shape, bbox_pred_shape, im_info_shape], [output_shape]
+
+    def create_operator(self, ctx, shapes, dtypes):
+        return ProposalOperator(self._feat_stride, self._scales, self._is_train, self._output_score)
+
+    def declare_backward_dependency(self, out_grad, in_data, out_data):
+        return []

--- a/python/mxnet/utils/rcnn_utils.py
+++ b/python/mxnet/utils/rcnn_utils.py
@@ -36,6 +36,8 @@ def nms(dets, thresh):
 
     return keep
 
+
+
 def bbox_transform_inv(boxes, deltas):
     if boxes.shape[0] == 0:
         return np.zeros((0, deltas.shape[1]), dtype=deltas.dtype)
@@ -69,6 +71,47 @@ def bbox_transform_inv(boxes, deltas):
 
     return pred_boxes
 
+
+def bbox_pred(boxes, box_deltas):
+    """
+    Transform the set of class-agnostic boxes into class-specific boxes
+    by applying the predicted offsets (box_deltas)
+    :param boxes: !important [N 4]
+    :param box_deltas: [N, 4 * num_classes]
+    :return: [N 4 * num_classes]
+    """
+    if boxes.shape[0] == 0:
+        return np.zeros((0, box_deltas.shape[1]))
+
+    boxes = boxes.astype(np.float, copy=False)
+    widths = boxes[:, 2] - boxes[:, 0] + 1.0
+    heights = boxes[:, 3] - boxes[:, 1] + 1.0
+    ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)
+    ctr_y = boxes[:, 1] + 0.5 * (heights - 1.0)
+
+    dx = box_deltas[:, 0::4]
+    dy = box_deltas[:, 1::4]
+    dw = box_deltas[:, 2::4]
+    dh = box_deltas[:, 3::4]
+
+    pred_ctr_x = dx * widths[:, np.newaxis] + ctr_x[:, np.newaxis]
+    pred_ctr_y = dy * heights[:, np.newaxis] + ctr_y[:, np.newaxis]
+    pred_w = np.exp(dw) * widths[:, np.newaxis]
+    pred_h = np.exp(dh) * heights[:, np.newaxis]
+
+    pred_boxes = np.zeros(box_deltas.shape)
+    # x1
+    pred_boxes[:, 0::4] = pred_ctr_x - 0.5 * (pred_w - 1.0)
+    # y1
+    pred_boxes[:, 1::4] = pred_ctr_y - 0.5 * (pred_h - 1.0)
+    # x2
+    pred_boxes[:, 2::4] = pred_ctr_x + 0.5 * (pred_w - 1.0)
+    # y2
+    pred_boxes[:, 3::4] = pred_ctr_y + 0.5 * (pred_h - 1.0)
+
+    return pred_boxes
+
+
 def clip_boxes(boxes, im_shape):
     """
     Clip boxes to image boundaries.
@@ -85,3 +128,74 @@ def clip_boxes(boxes, im_shape):
     # y2 < im_shape[0]
     boxes[:, 3::4] = np.minimum(boxes[:, 3::4], im_shape[0] - 1)
     return boxes
+
+
+#################
+#   Anchor      #
+#################
+
+def generate_anchors(base_size=16, ratios=[0.5, 1, 2],
+                     scales=2 ** np.arange(3, 6)):
+    """
+    Generate anchor (reference) windows by enumerating aspect ratios X
+    scales wrt a reference (0, 0, 15, 15) window.
+    """
+
+    base_anchor = np.array([1, 1, base_size, base_size]) - 1
+    ratio_anchors = _ratio_enum(base_anchor, ratios)
+    anchors = np.vstack([_scale_enum(ratio_anchors[i, :], scales)
+                         for i in xrange(ratio_anchors.shape[0])])
+    return anchors
+
+
+def _whctrs(anchor):
+    """
+    Return width, height, x center, and y center for an anchor (window).
+    """
+
+    w = anchor[2] - anchor[0] + 1
+    h = anchor[3] - anchor[1] + 1
+    x_ctr = anchor[0] + 0.5 * (w - 1)
+    y_ctr = anchor[1] + 0.5 * (h - 1)
+    return w, h, x_ctr, y_ctr
+
+
+def _mkanchors(ws, hs, x_ctr, y_ctr):
+    """
+    Given a vector of widths (ws) and heights (hs) around a center
+    (x_ctr, y_ctr), output a set of anchors (windows).
+    """
+
+    ws = ws[:, np.newaxis]
+    hs = hs[:, np.newaxis]
+    anchors = np.hstack((x_ctr - 0.5 * (ws - 1),
+                         y_ctr - 0.5 * (hs - 1),
+                         x_ctr + 0.5 * (ws - 1),
+                         y_ctr + 0.5 * (hs - 1)))
+    return anchors
+
+
+def _ratio_enum(anchor, ratios):
+    """
+    Enumerate a set of anchors for each aspect ratio wrt an anchor.
+    """
+
+    w, h, x_ctr, y_ctr = _whctrs(anchor)
+    size = w * h
+    size_ratios = size / ratios
+    ws = np.round(np.sqrt(size_ratios))
+    hs = np.round(ws * ratios)
+    anchors = _mkanchors(ws, hs, x_ctr, y_ctr)
+    return anchors
+
+
+def _scale_enum(anchor, scales):
+    """
+    Enumerate a set of anchors for each scale wrt an anchor.
+    """
+
+    w, h, x_ctr, y_ctr = _whctrs(anchor)
+    ws = w * scales
+    hs = h * scales
+    anchors = _mkanchors(ws, hs, x_ctr, y_ctr)
+    return anchors

--- a/python/mxnet/utils/rcnn_utils.py
+++ b/python/mxnet/utils/rcnn_utils.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+def nms(dets, thresh):
+    """
+    greedily select boxes with high confidence and overlap with current maximum <= thresh
+    rule out overlap >= thresh
+    :param dets: [[x1, y1, x2, y2 score]]
+    :param thresh: retain overlap < thresh
+    :return: indexes to keep
+    """
+    x1 = dets[:, 0]
+    y1 = dets[:, 1]
+    x2 = dets[:, 2]
+    y2 = dets[:, 3]
+    scores = dets[:, 4]
+
+    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
+    order = scores.argsort()[::-1]
+
+    keep = []
+    while order.size > 0:
+        i = order[0]
+        keep.append(i)
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx2 = np.minimum(x2[i], x2[order[1:]])
+        yy2 = np.minimum(y2[i], y2[order[1:]])
+
+        w = np.maximum(0.0, xx2 - xx1 + 1)
+        h = np.maximum(0.0, yy2 - yy1 + 1)
+        inter = w * h
+        ovr = inter / (areas[i] + areas[order[1:]] - inter)
+
+        inds = np.where(ovr <= thresh)[0]
+        order = order[inds + 1]
+
+    return keep
+
+def bbox_transform_inv(boxes, deltas):
+    if boxes.shape[0] == 0:
+        return np.zeros((0, deltas.shape[1]), dtype=deltas.dtype)
+
+    boxes = boxes.astype(deltas.dtype, copy=False)
+
+    widths = boxes[:, 2] - boxes[:, 0] + 1.0
+    heights = boxes[:, 3] - boxes[:, 1] + 1.0
+    ctr_x = boxes[:, 0] + 0.5 * widths
+    ctr_y = boxes[:, 1] + 0.5 * heights
+
+    dx = deltas[:, 0::4]
+    dy = deltas[:, 1::4]
+    dw = deltas[:, 2::4]
+    dh = deltas[:, 3::4]
+
+    pred_ctr_x = dx * widths[:, np.newaxis] + ctr_x[:, np.newaxis]
+    pred_ctr_y = dy * heights[:, np.newaxis] + ctr_y[:, np.newaxis]
+    pred_w = np.exp(dw) * widths[:, np.newaxis]
+    pred_h = np.exp(dh) * heights[:, np.newaxis]
+
+    pred_boxes = np.zeros(deltas.shape, dtype=deltas.dtype)
+    # x1
+    pred_boxes[:, 0::4] = pred_ctr_x - 0.5 * pred_w
+    # y1
+    pred_boxes[:, 1::4] = pred_ctr_y - 0.5 * pred_h
+    # x2
+    pred_boxes[:, 2::4] = pred_ctr_x + 0.5 * pred_w
+    # y2
+    pred_boxes[:, 3::4] = pred_ctr_y + 0.5 * pred_h
+
+    return pred_boxes
+
+def clip_boxes(boxes, im_shape):
+    """
+    Clip boxes to image boundaries.
+    :param boxes: [N, 4* num_classes]
+    :param im_shape: tuple of 2
+    :return: [N, 4* num_classes]
+    """
+    # x1 >= 0
+    boxes[:, 0::4] = np.maximum(boxes[:, 0::4], 0)
+    # y1 >= 0
+    boxes[:, 1::4] = np.maximum(boxes[:, 1::4], 0)
+    # x2 < im_shape[1]
+    boxes[:, 2::4] = np.minimum(boxes[:, 2::4], im_shape[1] - 1)
+    # y2 < im_shape[0]
+    boxes[:, 3::4] = np.minimum(boxes[:, 3::4], im_shape[0] - 1)
+    return boxes

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -34,7 +34,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
   ThreadedEnginePerDevice() noexcept(false) {
     gpu_worker_nthreads_ = common::GetNumThreadPerGPU();
     gpu_copy_nthreads_ = dmlc::GetEnv("MXNET_GPU_COPY_NTHREADS", 1);
-    cpu_worker_nthreads_ = dmlc::GetEnv("MXNET_CPU_WORKER_NTHREADS", 1);
+    cpu_worker_nthreads_ = dmlc::GetEnv("MXNET_CPU_WORKER_NTHREADS", 2);
     // create CPU task
     int cpu_priority_nthreads = dmlc::GetEnv("MXNET_CPU_PRIORITY_NTHREADS", 4);
     cpu_priority_worker_.reset(new ThreadWorkerBlock<kPriorityQueue>());

--- a/src/operator/native_op-inl.h
+++ b/src/operator/native_op-inl.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 by Contributors
  * \file native_op-inl.h
  * \brief
- * \author Junyuan Xie
+ * \author Junyuan Xie, Bing Xu
 */
 
 #ifndef MXNET_OPERATOR_NATIVE_OP_INL_H_
@@ -15,11 +15,16 @@
 #include <vector>
 #include <string>
 #include <utility>
-#include <sstream>
 #include "./operator_common.h"
 
 namespace mxnet {
 namespace op {
+
+namespace nativeop {
+enum NativeOpSyncDirection {kTensorToData, kDataToTensor};
+enum NativeOpResource {kTempSpace};
+}
+
 
 struct NativeOpParam : public dmlc::Parameter<NativeOpParam> {
   void *info;
@@ -36,7 +41,132 @@ struct NativeOpParam : public dmlc::Parameter<NativeOpParam> {
 };
 
 template<typename xpu>
-class NativeOp : public Operator {
+class NativeOpBase : public Operator {
+ public:
+  virtual ExecType exec_type() const {
+    return kAsync;
+  }
+
+ protected:
+  inline uint64_t _CalculateSpace(const std::vector<TBlob> &tblob_vec) {
+    uint64_t size = 0;
+    for (size_t i = 0; i < tblob_vec.size(); ++i) {
+      size += tblob_vec[i].shape_.Size();
+    }
+    return size;
+  }
+
+  inline void _InitDataVector(const std::vector<TBlob> &tblob_vec,
+                              std::vector<real_t*> *vec,
+                              real_t *buf,
+                              uint64_t *buf_size);
+
+
+  inline void _InitForward(const OpContext &ctx,
+                           const std::vector<TBlob> &in_data,
+                           const std::vector<TBlob> &out_data,
+                           const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    in_data_ptr_.resize(in_data.size());
+    out_data_ptr_.resize(out_data.size());
+    aux_args_ptr_.resize(aux_args.size());
+    uint64_t buf_size = 0;
+    buf_size += _CalculateSpace(in_data);
+    buf_size += _CalculateSpace(out_data);
+    buf_size += _CalculateSpace(aux_args);
+    Tensor<cpu, 1> buf = ctx.requested[nativeop::kTempSpace].get_host_space_typed<1, real_t>(
+      Shape1(buf_size));
+    buf_size = 0;
+    _InitDataVector(in_data, &in_data_ptr_, buf.dptr_, &buf_size);
+    _InitDataVector(out_data, &out_data_ptr_, buf.dptr_, &buf_size);
+    _InitDataVector(aux_args, &aux_args_ptr_, buf.dptr_, &buf_size);
+  }
+
+  inline void _InitBackward(const OpContext &ctx,
+                            const std::vector<TBlob> &out_grad,
+                            const std::vector<TBlob> &in_data,
+                            const std::vector<TBlob> &out_data,
+                            const std::vector<TBlob> &in_grad,
+                            const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    out_grad_ptr_.resize(out_grad.size());
+    in_data_ptr_.resize(in_data.size());
+    out_data_ptr_.resize(out_data.size());
+    in_grad_ptr_.resize(in_grad.size());
+    aux_args_ptr_.resize(aux_args.size());
+    uint64_t buf_size = 0;
+    buf_size += _CalculateSpace(out_grad);
+    buf_size += _CalculateSpace(in_data);
+    buf_size += _CalculateSpace(out_data);
+    buf_size += _CalculateSpace(in_grad);
+    buf_size += _CalculateSpace(aux_args);
+    Tensor<cpu, 1> buf = ctx.requested[nativeop::kTempSpace].get_host_space_typed<1, real_t>(
+      Shape1(buf_size));
+    buf_size = 0;
+    _InitDataVector(out_grad, &out_grad_ptr_, buf.dptr_, &buf_size);
+    _InitDataVector(in_data, &in_data_ptr_, buf.dptr_, &buf_size);
+    _InitDataVector(out_data, &out_data_ptr_, buf.dptr_, &buf_size);
+    _InitDataVector(in_grad, &in_grad_ptr_, buf.dptr_, &buf_size);
+    _InitDataVector(aux_args, &aux_args_ptr_, buf.dptr_, &buf_size);
+  }
+
+  inline void _SyncData(const std::vector<TBlob> &data,
+                        const std::vector<real_t*> &vec,
+                        mshadow::Stream<xpu> *s,
+                        nativeop::NativeOpSyncDirection dir) {
+    using namespace mshadow;
+    for (size_t i = 0; i < data.size(); ++i) {
+      Tensor<xpu, 2> tensor_data = data[i].FlatTo2D<xpu, real_t>(s);
+      Tensor<cpu, 2> vector_data = Tensor<cpu, 2>(vec[i], tensor_data.shape_);
+      if (tensor_data.dptr_ == vector_data.dptr_) {
+        continue;
+      }
+      switch (dir) {
+      case nativeop::kTensorToData:
+        Copy(vector_data, tensor_data, s);
+        break;
+      case nativeop::kDataToTensor:
+        Copy(tensor_data, vector_data, s);
+        break;
+      default:
+        LOG(FATAL) << "Not reach";
+      }
+    }
+    // s->Wait();
+  }
+
+ protected:
+  std::vector<real_t*> in_data_ptr_;
+  std::vector<real_t*> out_data_ptr_;
+  std::vector<real_t*> aux_args_ptr_;
+  std::vector<real_t*> out_grad_ptr_;
+  std::vector<real_t*> in_grad_ptr_;
+};  // NativeOpBase
+
+template<>
+inline void NativeOpBase<gpu>::_InitDataVector(const std::vector<TBlob> &tblob_vec,
+                                               std::vector<real_t*> *vec,
+                                               real_t *buf,
+                                               uint64_t *buf_size) {
+  for (size_t i = 0; i < tblob_vec.size(); ++i) {
+    vec->at(i) = buf + (*buf_size);
+    (*buf_size) += tblob_vec[i].shape_.Size();
+  }
+}
+
+template<>
+inline void NativeOpBase<cpu>::_InitDataVector(const std::vector<TBlob> &tblob_vec,
+                                               std::vector<real_t*> *vec,
+                                               real_t *buf,
+                                               uint64_t *buf_size) {
+  for (size_t i = 0; i < tblob_vec.size(); ++i) {
+    vec->at(i) = static_cast<real_t*>(tblob_vec[i].dptr_);
+  }
+}
+
+
+template<typename xpu>
+class NativeOp : public NativeOpBase<xpu> {
  public:
   explicit NativeOp(NativeOpParam p) {
     this->param_ = p;
@@ -49,25 +179,19 @@ class NativeOp : public Operator {
                        const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     Stream<xpu> *s = ctx.get_stream<xpu>();
-    ptrs.clear();
-    ndims.clear();
-    shapes.clear();
-    tags.clear();
-    SyncVec(in_data, "in_data", s, 0);
-    SyncVec(out_data, "out_data", s, 1);
-    s->Wait();
-    param_.pinfo->forward(ptrs.size(), ptrs.data(), ndims.data(), shapes.data(),
-        tags.data(), param_.pinfo->p_forward);
-    for (index_t i = 0; i < out_data.size(); ++i) {
-      CHECK_NE(req[i], kAddTo) << "NativeOp doesn't support AddTo for output";
-      if (req[i] != kNullOp) {
-        std::stringstream ss;
-        ss << std::string("out_data") << i;
-        Copy(out_data[i].FlatTo2D<xpu, real_t>(s),
-             buffer_map[ss.str()].second, s);
-      }
-    }
-    s->Wait();
+    Parent::_InitForward(ctx, in_data, out_data, aux_args);
+    Parent::_SyncData(in_data, Parent::in_data_ptr_, s, nativeop::kTensorToData);
+    Parent::_SyncData(aux_args, Parent::aux_args_ptr_, s,  nativeop::kTensorToData);
+    this->_InitNativeForward(in_data, out_data, aux_args);
+    if (s!= NULL) s->Wait();
+    param_.pinfo->forward(ptrs_.size(), ptrs_.data(),
+                          ndims_.data(), shapes_.data(),
+                          tags_.data(),
+                          param_.pinfo->p_forward);
+    Parent::_SyncData(out_data, Parent::out_data_ptr_, s, nativeop::kDataToTensor);
+    Parent::_SyncData(aux_args, Parent::aux_args_ptr_, s, nativeop::kDataToTensor);
+    if (s != NULL) s->Wait();
+    ctx.async_on_complete();
   }
 
   virtual void Backward(const OpContext &ctx,
@@ -79,74 +203,82 @@ class NativeOp : public Operator {
                         const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     Stream<xpu> *s = ctx.get_stream<xpu>();
-    ptrs.clear();
-    ndims.clear();
-    shapes.clear();
-    tags.clear();
-    SyncVec(in_data, "in_data", s, 0);
-    SyncVec(out_data, "out_data", s, 1);
-    SyncVec(in_grad, "in_grad", s, 2);
+    Parent::_InitBackward(ctx, out_grad, in_data, out_data, in_grad, aux_args);
     if (param_.need_top_grad) {
-      SyncVec(out_grad, "out_grad", s, 3);
+      Parent::_SyncData(out_grad, Parent::out_grad_ptr_, s, nativeop::kTensorToData);
     }
-    s->Wait();
-    param_.pinfo->backward(ptrs.size(), ptrs.data(), ndims.data(), shapes.data(),
-        tags.data(), param_.pinfo->p_backward);
-    for (index_t i = 0; i < in_grad.size(); ++i) {
-      CHECK_NE(req[i], kAddTo) << "NativeOp doesn't support AddTo for output";
-      if (req[i] != kNullOp) {
-        std::stringstream ss;
-        ss << std::string("in_grad") << i;
-        Copy(in_grad[i].FlatTo2D<xpu, real_t>(s),
-             buffer_map[ss.str()].second, s);
-      }
+    Parent::_SyncData(in_data, Parent::in_data_ptr_, s, nativeop::kTensorToData);
+    Parent::_SyncData(out_data, Parent::out_data_ptr_, s, nativeop::kTensorToData);
+    this->_InitNativeBackward(out_grad, in_data, out_data, in_grad, aux_args);
+    if (s != NULL) s->Wait();
+    param_.pinfo->backward(ptrs_.size(), ptrs_.data(),
+                           ndims_.data(), shapes_.data(),
+                           tags_.data(),
+                           param_.pinfo->p_backward);
+    Parent::_SyncData(in_grad, Parent::in_grad_ptr_, s, nativeop::kDataToTensor);
+    Parent::_SyncData(aux_args, Parent::aux_args_ptr_, s, nativeop::kDataToTensor);
+    if (s != NULL) s->Wait();
+    ctx.async_on_complete();
+  }
+
+ private:
+  typedef NativeOpBase<xpu> Parent;
+  inline void _InitNativeEntry(const std::vector<TBlob> &tblob_vec,
+                               const std::vector<real_t*> &vec,
+                               int tag,
+                               uint64_t *idx) {
+    for (size_t i = 0; i < vec.size(); ++i) {
+      ptrs_[*idx] = vec[i];
+      ndims_[*idx] = tblob_vec[i].ndim();
+      shapes_[*idx] = const_cast<index_t*>(tblob_vec[i].shape_.data());
+      tags_[*idx] = tag;
+      ++(*idx);
     }
-    s->Wait();
+  }
+  inline void _InitNativeForward(const std::vector<TBlob> &in_data,
+                                 const std::vector<TBlob> &out_data,
+                                 const std::vector<TBlob> &aux_args) {
+    uint64_t size = in_data.size() + out_data.size();
+    ptrs_.resize(size);
+    ndims_.resize(size);
+    shapes_.resize(size);
+    tags_.resize(size);
+    uint64_t idx = 0;
+    _InitNativeEntry(in_data, Parent::in_data_ptr_, 0, &idx);
+    _InitNativeEntry(out_data, Parent::out_data_ptr_, 1, &idx);
+    // _InitNativeEntry(aux_args, aux_args_ptr_, 4, &idx);
+  }
+
+  inline void _InitNativeBackward(const std::vector<TBlob> &out_grad,
+                                  const std::vector<TBlob> &in_data,
+                                  const std::vector<TBlob> &out_data,
+                                  const std::vector<TBlob> &in_grad,
+                                  const std::vector<TBlob> &aux_args) {
+    uint64_t size = (param_.need_top_grad ? out_grad.size() : 0) +
+                    in_data.size() +
+                    out_data.size() +
+                    in_grad.size();
+                    // aux_args_ptr_.size();
+    ptrs_.resize(size);
+    ndims_.resize(size);
+    shapes_.resize(size);
+    tags_.resize(size);
+    uint64_t idx = 0;
+    _InitNativeEntry(in_data, Parent::in_data_ptr_, 0, &idx);
+    _InitNativeEntry(out_data, Parent::out_data_ptr_, 1, &idx);
+    _InitNativeEntry(in_grad, Parent::in_grad_ptr_, 2, &idx);
+    if (param_.need_top_grad) {
+      _InitNativeEntry(out_grad, Parent::out_grad_ptr_, 3, &idx);
+    }
+    // _InitNativeEntry(aux_args, aux_args_ptr_, 4, &idx);
   }
 
  private:
   NativeOpParam param_;
-  std::vector<real_t*> ptrs;
-  std::vector<int> ndims;
-  std::vector<unsigned*> shapes;
-  std::vector<int> tags;
-  std::map<std::string, std::pair<TShape, mshadow::Tensor<cpu, 2> > > buffer_map;
-
-  virtual void SyncBuffer(const TBlob &tblob,
-                          const std::string &name,
-                          mshadow::Stream<xpu> *stream) {
-    using namespace mshadow;
-    std::map<std::string, std::pair<TShape, mshadow::Tensor<cpu, 2> > >::iterator buffer =
-      buffer_map.find(name);
-    if (buffer == buffer_map.end() || buffer->second.first != tblob.shape_) {
-      if (buffer != buffer_map.end()) {
-        FreeSpace<2, real_t>(&(buffer->second.second));
-        buffer_map.erase(buffer);
-      }
-      buffer_map[name] =
-        std::pair<TShape, Tensor<cpu, 2> >(tblob.shape_,
-                                         NewTensor<cpu>(tblob.shape_.FlatTo2D(),
-                                                        0.0f,
-                                                        false));
-      buffer = buffer_map.find(name);
-    }
-    Copy(buffer->second.second, tblob.FlatTo2D<xpu, real_t>(stream), stream);
-  }
-
-  virtual void SyncVec(const std::vector<TBlob> &vec,
-                       const std::string &prefix,
-                       mshadow::Stream<xpu> *stream,
-                       int tag) {
-    for (size_t i = 0; i < vec.size(); ++i) {
-      std::stringstream name;
-      name << prefix << i;
-      SyncBuffer(vec[i], name.str(), stream);
-      ptrs.push_back(buffer_map[name.str()].second.dptr_);
-      ndims.push_back(vec[i].ndim());
-      shapes.push_back(const_cast<index_t*>(vec[i].shape_.data()));
-      tags.push_back(tag);
-    }
-  }
+  std::vector<real_t*> ptrs_;
+  std::vector<int> ndims_;
+  std::vector<unsigned*> shapes_;
+  std::vector<int> tags_;
 };  // NativeOp
 
 template<typename xpu>
@@ -247,6 +379,16 @@ class NativeOpProp : public OperatorProperty {
     const std::vector<int> &out_data,
     const std::vector<void*> &in_grad) const override {
     return {};
+  }
+
+  std::vector<ResourceRequest> BackwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
   }
 
   Operator* CreateOperator(Context ctx) const override;

--- a/src/operator/native_op-inl.h
+++ b/src/operator/native_op-inl.h
@@ -42,11 +42,6 @@ struct NativeOpParam : public dmlc::Parameter<NativeOpParam> {
 
 template<typename xpu>
 class NativeOpBase : public Operator {
- public:
-  virtual ExecType exec_type() const {
-    return kAsync;
-  }
-
  protected:
   inline uint64_t _CalculateSpace(const std::vector<TBlob> &tblob_vec) {
     uint64_t size = 0;

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -15,9 +15,94 @@
 #include <istream>
 #include <ostream>
 #include <string>
+#include <vector>
 
 namespace mxnet {
 namespace op {
+
+/*!
+* \brief structure for numerical tuple input
+* \tparam VType data type of param
+*/
+template<typename VType>
+struct NumericalParam {
+  NumericalParam() {}
+  explicit NumericalParam(VType *begin, VType *end) {
+    int32_t size = static_cast<int32_t>(end - begin);
+    info.resize(size);
+    for (int i = 0; i < size; ++i) {
+      info[i] = *(begin + i);
+    }
+  }
+  inline size_t ndim() const {
+    return info.size();
+  }
+  std::vector<VType> info;
+};
+
+template<typename VType>
+inline std::istream &operator>>(std::istream &is, NumericalParam<VType> &param) {
+  while (true) {
+    char ch = is.get();
+    if (ch == '(') break;
+    if (!isspace(ch)) {
+      is.setstate(std::ios::failbit);
+      return is;
+    }
+  }
+  VType idx;
+  std::vector<VType> tmp;
+  // deal with empty case
+  size_t pos = is.tellg();
+  char ch = is.get();
+  if (ch == ')') {
+    param.info = tmp;
+    return is;
+  }
+  is.seekg(pos);
+  // finish deal
+  while (is >> idx) {
+    tmp.push_back(idx);
+    char ch;
+    do {
+      ch = is.get();
+    } while (isspace(ch));
+    if (ch == ',') {
+      while (true) {
+        ch = is.peek();
+        if (isspace(ch)) {
+          is.get(); continue;
+        }
+        if (ch == ')') {
+          is.get(); break;
+        }
+        break;
+      }
+      if (ch == ')') break;
+    } else if (ch == ')') {
+      break;
+    } else {
+      is.setstate(std::ios::failbit);
+      return is;
+    }
+  }
+  param.info = tmp;
+  return is;
+}
+
+template<typename VType>
+inline std::ostream &operator<<(std::ostream &os, const NumericalParam<VType> &param) {
+  os << '(';
+  for (index_t i = 0; i < param.info.size(); ++i) {
+    if (i != 0) os << ',';
+    os << param.info[i];
+  }
+  // python style tuple
+  if (param.info.size() == 1) os << ',';
+  os << ')';
+  return os;
+}
+
 /*!
  * \brief assign the expression to out according to request
  * \param out the data to be assigned

--- a/src/operator/proposal-inl.h
+++ b/src/operator/proposal-inl.h
@@ -1,0 +1,299 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file proposal-inl.h
+ * \brief
+ * \author Piotr Teterwak
+*/
+#ifndef MXNET_OPERATOR_PROPOSAL_INL_H_
+#define MXNET_OPERATOR_PROPOSAL_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "./operator_common.h"
+#include "./mshadow_op.h"
+#include "./native_op-inl.h"
+#include "./rcnn_utils.h"
+
+
+namespace mxnet {
+namespace op {
+
+namespace proposal {
+enum ProposalOpType {kTrain, kTest};
+enum ProposalOpInputs {kClsProb, kBBoxPred, kImInfo};
+enum ProposalOpOutputs {kOut, kPad, kTempProposal, kTempNMS};
+enum ProposalOpResource {kTempSpace};
+}  // proposal
+
+
+struct ProposalParam : public dmlc::Parameter<ProposalParam> {
+  int phrase;
+  int rpn_pre_nms_top_n;
+  int rpn_post_nms_top_n;
+  float threshold;
+  int rpn_min_size;
+  NumericalParam<float> scales;
+  NumericalParam<float> ratios;
+  NumericalParam<float> base_anchor;
+  int feature_stride;
+  DMLC_DECLARE_PARAMETER(ProposalParam) {
+    float tmp[] = {0, 0, 0, 0};
+    DMLC_DECLARE_FIELD(phrase)
+    .add_enum("train", proposal::kTrain)
+    .add_enum("test", proposal::kTest)
+    .set_default(proposal::kTest)
+    .describe("The phrase will use proposal op");
+    DMLC_DECLARE_FIELD(rpn_pre_nms_top_n).set_default(6000)
+    .describe("Number of top scoring boxes to keep after applying NMS to RPN proposals");
+    DMLC_DECLARE_FIELD(rpn_post_nms_top_n).set_default(300)
+    .describe("Overlap threshold used for non-maximum"
+              "suppresion(suppress boxes with IoU >= this threshold");
+    DMLC_DECLARE_FIELD(threshold).set_default(0.7)
+    .describe("NMS value, below which to suppress.");
+    DMLC_DECLARE_FIELD(rpn_min_size).set_default(16)
+    .describe("Minimum height or width in proposal");
+    tmp[0] = 4.0f; tmp[1] = 8.0f; tmp[2] = 16.0f; tmp[3] = 32.0f;
+    DMLC_DECLARE_FIELD(scales).set_default(NumericalParam<float>(tmp, tmp + 4))
+    .describe("Used to generate anchor windows by enumerating scales");
+    tmp[0] = 0.5f; tmp[1] = 1.0f; tmp[2] = 2.0f;
+    DMLC_DECLARE_FIELD(ratios).set_default(NumericalParam<float>(tmp, tmp + 3))
+    .describe("Used to generate anchor windows by enumerating ratios");
+    tmp[0] = 0.0f; tmp[1] = 0.0f; tmp[2] = 15.0f; tmp[3] = 15.0f;
+    DMLC_DECLARE_FIELD(base_anchor).set_default(NumericalParam<float>(tmp, tmp + 4))
+    .describe("The base anchor that is used as reference anchor for generating anchors.");
+    DMLC_DECLARE_FIELD(feature_stride).set_default(16)
+    .describe("The size of the receptive field each unit in the convolution layer of the rpn,"
+              "for example the product of all stride's prior to this layer.");
+  }
+};
+
+template<typename xpu>
+class ProposalOp : public NativeOpBase<xpu> {
+ public:
+  explicit ProposalOp(ProposalParam param) {
+    this->param_ = param;
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_states) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 3);
+    CHECK_EQ(out_data.size(), 4);
+    CHECK_GT(req.size(), 1);
+    CHECK_EQ(req[proposal::kOut], kWriteTo);
+
+
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    Parent::_InitForward(ctx, in_data, out_data, aux_states);
+    Parent::_SyncData(in_data, Parent::in_data_ptr_, s, nativeop::kTensorToData);
+    if (s != NULL) s->Wait();
+
+    size_t num_anchors = in_data[proposal::kClsProb].shape_[1] / 2;
+    Shape<4> scores_shape = Shape4(in_data[proposal::kClsProb].shape_[0],
+                                   in_data[proposal::kClsProb].shape_[1] / 2,
+                                   in_data[proposal::kClsProb].shape_[2],
+                                   in_data[proposal::kClsProb].shape_[3]);
+
+
+    Shape<4> bbox_deltas_shape = Shape4(in_data[proposal::kBBoxPred].shape_[0],
+                                        in_data[proposal::kBBoxPred].shape_[1],
+                                        in_data[proposal::kBBoxPred].shape_[2],
+                                        in_data[proposal::kBBoxPred].shape_[3]);
+
+    Shape<2> im_info_shape = Shape2(in_data[proposal::kImInfo].shape_[0],
+                                    in_data[proposal::kImInfo].shape_[1]);
+
+    Shape<2> out_shape = Shape2(out_data[proposal::kOut].shape_[0],
+                                out_data[proposal::kOut].shape_[1]);
+
+    Shape<2> workspace_proposals_shape = Shape2(out_data[proposal::kTempProposal].shape_[0],
+                                                out_data[proposal::kTempProposal].shape_[1]);
+
+    Shape<2> workspace_nms_shape = Shape2(out_data[proposal::kTempNMS].shape_[0],
+                                          out_data[proposal::kTempNMS].shape_[1]);
+
+    real_t* foreground_score_pointer =
+      Parent::in_data_ptr_[proposal::kClsProb] + scores_shape.Size();
+
+    Tensor<cpu, 4> scores =  Tensor<cpu, 4>(foreground_score_pointer, scores_shape);
+    Tensor<cpu, 4> bbox_deltas = Tensor<cpu, 4>(Parent::in_data_ptr_[proposal::kBBoxPred],
+                                                bbox_deltas_shape);
+    Tensor<cpu, 2> im_info = Tensor<cpu, 2>(Parent::in_data_ptr_[proposal::kImInfo],
+                                            im_info_shape);
+
+    Tensor<cpu, 2> out = Tensor<cpu, 2>(Parent::out_data_ptr_[proposal::kOut],
+                                        out_shape);
+
+    Tensor<cpu, 2> workspace_proposals =
+      Tensor<cpu, 2>(Parent::out_data_ptr_[proposal::kTempProposal], workspace_proposals_shape);
+
+    Tensor<cpu, 2> workspace_nms = Tensor<cpu, 2>(Parent::out_data_ptr_[proposal::kTempNMS],
+                                                  workspace_nms_shape);
+    index_t height = scores.size(2);
+    index_t width = scores.size(3);
+
+    utils::GenerateAnchors(param_.base_anchor.info,
+                           param_.ratios.info,
+                           param_.scales.info,
+                           &workspace_proposals);
+
+    //Enumerate all shifted anchors
+    for (index_t i = 0; i < num_anchors; ++i){
+      for (index_t j = 0; j < height; ++j){
+        for (index_t k = 0; k < width; ++k){
+          index_t index = j * (width * num_anchors) + k * (num_anchors) + i;
+          workspace_proposals[index][0] = workspace_proposals[i][0] + k * param_.feature_stride;
+          workspace_proposals[index][1] = workspace_proposals[i][1] + j * param_.feature_stride;
+          workspace_proposals[index][2] = workspace_proposals[i][2] + k * param_.feature_stride;
+          workspace_proposals[index][3] = workspace_proposals[i][3] + j * param_.feature_stride;
+        }
+      }
+    }
+
+    //Copy scores to workspace.
+    for (index_t i = 0; i < num_anchors; i++) {
+      for (index_t h = 0; h < height; h++) {
+        for (index_t w = 0; w < width; w++) {
+          index_t index = h * (width * num_anchors) + w * (num_anchors) + i;
+          workspace_proposals[index][4] = scores[0][i][h][w];
+        }
+      }
+    }
+
+    utils::BBoxTransformInv(workspace_proposals, bbox_deltas, &(workspace_proposals));
+    utils::ClipBoxes(Shape2(im_info[0][0],im_info[0][1]), &(workspace_proposals));
+
+    real_t scale = im_info[0][2];
+    index_t out_size = 0;
+    Tensor<cpu, 1> output = workspace_nms[4];
+
+    utils::NonMaximumSuppression(workspace_proposals,
+                                 param_.threshold,
+                                 param_.rpn_min_size * scale, param_.rpn_pre_nms_top_n,
+                                 param_.rpn_post_nms_top_n,
+                                 &workspace_nms,
+                                 &output,
+                                 &out_size);
+
+    for (index_t i = 0; i < out.size(0); ++i) {
+      index_t index = output[i];
+      //batch index 0
+      out[i][0] = 0;
+      for (index_t j = 0; j < 4; ++j) {
+        if (i < out_size) {
+          out[i][j + 1] =  workspace_proposals[index][j];
+        } else {
+          out[i][j + 1] = 0;
+        }
+      }
+    }
+    if (param_.phrase == proposal::kTrain) {
+      Tensor<cpu, 1> output_pad = Tensor<cpu, 1>(Parent::out_data_ptr_[proposal::kPad], Shape1(1));
+      output_pad[0] = out.size(0) - out_size;
+    }
+    Parent::_SyncData(out_data, Parent::out_data_ptr_, s, nativeop::kDataToTensor);
+    if (s != NULL) s->Wait();
+    ctx.async_on_complete();
+  }
+
+ private:
+  ProposalParam param_;
+  typedef NativeOpBase<xpu> Parent;
+};  // class ProposalOp
+
+template<typename xpu>
+Operator *CreateOp(ProposalParam param);
+
+
+#if DMLC_USE_CXX11
+class ProposalProp : public OperatorProperty {
+ public:
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 3) << "Input:[cls_prob, bbox_pred, im_info]";
+    const TShape &dshape = in_shape->at(proposal::kClsProb);
+    if (dshape.ndim() == 0) return false;
+    Shape<4> bbox_pred_shape;
+    bbox_pred_shape = Shape4(dshape[0], dshape[1] * 2, dshape[2], dshape[3]);
+    SHAPE_ASSIGN_CHECK(*in_shape, proposal::kBBoxPred,
+                       bbox_pred_shape);
+    Shape<2> im_info_shape;
+    im_info_shape = Shape2(1, 3);
+    SHAPE_ASSIGN_CHECK(*in_shape, proposal::kImInfo, im_info_shape);
+    out_shape->clear();
+    out_shape->push_back(Shape2(param_.rpn_post_nms_top_n, 5));
+    out_shape->push_back(Shape1(1));
+    out_shape->push_back(Shape2((dshape[1] / 2) * dshape[2] * dshape[3], 5));
+    out_shape->push_back(Shape2(5, dshape[1] / 2 * dshape[2] * dshape[3]));
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new ProposalProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "Proposal";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    return {};
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
+  }
+
+  int NumVisibleOutputs() const override {
+    return param_.phrase == proposal::kTrain ? 2 : 1;
+  }
+
+  int NumOutputs() const override {
+    return 4;
+  }
+
+  //todo fix all parameters
+  std::vector<std::string> ListArguments() const override {
+    return {"rpn_cls_prob", "rpn_bbox_pred", "im_info"};
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    return {"rois", "rois_pad", "temp_proposal", "temp_nms"};
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  ProposalParam param_;
+};  // class ProposalProp
+
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  //  MXNET_OPERATOR_PROPOSAL_INL_H_
+

--- a/src/operator/proposal-inl.h
+++ b/src/operator/proposal-inl.h
@@ -283,7 +283,7 @@ class ProposalProp : public OperatorProperty {
   }
 
   std::vector<std::string> ListOutputs() const override {
-    return {"rois", "rois_pad", "temp_proposal", "temp_nms"};
+    return {"output", "output_pad", "temp_proposal", "temp_nms"};
   }
 
   Operator* CreateOperator(Context ctx) const override;

--- a/src/operator/proposal-inl.h
+++ b/src/operator/proposal-inl.h
@@ -202,7 +202,6 @@ class ProposalOp : public NativeOpBase<xpu> {
     }
     Parent::_SyncData(out_data, Parent::out_data_ptr_, s, nativeop::kDataToTensor);
     if (s != NULL) s->Wait();
-    ctx.async_on_complete();
   }
 
  private:

--- a/src/operator/proposal.cc
+++ b/src/operator/proposal.cc
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file proposal.cc
+ * \brief
+ * \author Piotr Teterwak
+*/
+
+#include "./proposal-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(ProposalParam param) {
+  return new ProposalOp<cpu>(param);
+}
+
+Operator* ProposalProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(ProposalParam);
+
+MXNET_REGISTER_OP_PROPERTY(Proposal, ProposalProp)
+.describe("Generate region proposals via RPN")
+.add_argument("rpn_cls_score", "Symbol", "Score of how likely proposal is object.")
+.add_argument("rpn_bbox_pred", "Symbol", "BBox Predicted deltas from anchors for proposals")
+.add_argument("im_info", "Symbol", "Image size and scale.")
+.add_arguments(ProposalParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet
+

--- a/src/operator/proposal.cu
+++ b/src/operator/proposal.cu
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file proposal.cu
+ * \brief proposal operator
+*/
+#include "./proposal-inl.h"
+namespace mxnet {
+namespace op {
+template<>
+Operator* CreateOp<gpu>(ProposalParam param) {
+  return new ProposalOp<gpu>(param);
+}
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/rcnn_utils.h
+++ b/src/operator/rcnn_utils.h
@@ -1,0 +1,360 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file rcnn_utils.h
+ * \brief
+ * \author Bing Xu
+*/
+#ifndef MXNET_OPERATOR_RCNN_UTILS_H_
+#define MXNET_OPERATOR_RCNN_UTILS_H_
+#include <algorithm>
+#include <mshadow/tensor.h>
+#include <mshadow/extension.h>
+
+namespace mshadow {
+namespace expr {
+//=========================
+// BBox Overlap mshadow exp
+//=========================
+/*!
+ * \brief 2D overlap expression
+ * \tparam SrcExp source expression to be calculated
+ * \tparam DType data type
+ * \tparam srcdim dimension of src
+ */
+template<typename SrcExp, typename DType, int srcdim>
+struct OverlapExp: public MakeTensorExp<OverlapExp<SrcExp, DType, srcdim>,
+                                        SrcExp, srcdim, DType> {
+  /*! \brief boxes */
+  const SrcExp &lhs_;
+  /*! \brief query_boxes */
+  const SrcExp &rhs_;
+  /*! \brief constructor */
+  explicit OverlapExp(const SrcExp &lhs, const SrcExp &rhs)
+    : lhs_(lhs), rhs_(rhs) {
+    // lhs shape: (N, 4)
+    // rhs shape: (K, 4)
+    // output : (N, K)
+    CHECK_EQ(srcdim, 2) << "Input must be 2D Tensor";
+    this->shape_ = ShapeCheck<srcdim, SrcExp>::Check(lhs_);
+    Shape<2> rhs_shape = ShapeCheck<srcdim, SrcExp>::Check(rhs_);
+    CHECK_EQ(this->shape_[1], 4) << "boxes must be in shape (N, 4)";
+    CHECK_EQ(rhs_shape[1], 4) << "query box must be in shape (K, 4)";
+    this->shape_[1] = rhs_shape[0];
+  }
+};  // struct OverlapExp
+
+/*!
+ * \brief calcuate overlaps between boxes and query boxes
+ * \param lhs boxes
+ * \param rhs query boxes
+ * \tparam SrcExp source expression
+ * \tparam DType data type
+ * \tparam srcdim dimension of src
+ */
+template<typename SrcExp, typename DType, int etype>
+inline OverlapExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
+bbox_overlaps(const Exp<SrcExp, DType, etype> &lhs,
+             const Exp<SrcExp, DType, etype> &rhs) {
+  TypeCheckPass<ExpInfo<SrcExp>::kDim == 2>::Error_Expression_Does_Not_Meet_Dimension_Req();
+  return OverlapExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
+    (lhs.self(), rhs.self());
+}
+
+//----------------------
+// Execution plan
+//----------------------
+
+template<typename SrcExp, typename DType, int srcdim>
+struct Plan<OverlapExp<SrcExp, DType, srcdim>, DType> {
+ public:
+  explicit Plan(const OverlapExp<SrcExp, DType, srcdim> &e)
+    : lhs_(MakePlan(e.lhs_)),
+      rhs_(MakePlan(e.rhs_)) {}
+  MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
+    DType box_area =
+      (rhs_.Eval(j, 2) - rhs_.Eval(j, 0) + 1) *
+      (rhs_.Eval(j, 3) - rhs_.Eval(j, 1) + 1);
+    DType iw =
+      (lhs_.Eval(i, 2) < rhs_.Eval(j, 2) ? lhs_.Eval(i, 2) : rhs_.Eval(j, 2)) -
+      (lhs_.Eval(i, 0) > rhs_.Eval(j, 0) ? lhs_.Eval(i, 0) : rhs_.Eval(j, 0)) + 1;
+    if (iw < 0.0f) {
+      return DType(0.0f);
+    } else {
+      DType ih =
+        (lhs_.Eval(i, 3) < rhs_.Eval(j, 3) ? lhs_.Eval(i, 3) : rhs_.Eval(j, 3)) -
+        (lhs_.Eval(i, 1) > rhs_.Eval(j, 1) ? lhs_.Eval(i, 1) : rhs_.Eval(j, 1)) + 1;
+      if (ih < 0.0f) {
+        return DType(0.0f);
+      } else {
+        DType ua =
+          (lhs_.Eval(i, 2) - lhs_.Eval(i, 0) + 1) *
+          (lhs_.Eval(i, 3) - lhs_.Eval(i, 1) + 1) +
+          box_area - iw * ih;
+        return DType(iw * ih / ua);
+      }
+    }
+  }
+
+ private:
+  Plan<SrcExp, DType> lhs_;
+  Plan<SrcExp, DType> rhs_;
+};  // struct Plan
+
+}  // namespace expr
+}  // namespace mshadow
+
+//=====================
+// NMS Utils
+//=====================
+namespace mxnet {
+namespace op {
+namespace utils {
+
+struct ReverseArgsortCompl {
+  const float *val_;
+  explicit ReverseArgsortCompl(float *val)
+    : val_(val) {}
+  bool operator() (float i, float j) {
+    return (val_[static_cast<index_t>(i)] >
+            val_[static_cast<index_t>(j)]);
+  }
+};
+
+inline void NonMaximumSuppression(const mshadow::Tensor<cpu, 2> &dets,
+                                  const float thresh,
+                                  const float min_size,
+                                  const index_t pre_nms_top_n,
+                                  const index_t post_nms_top_n,
+                                  mshadow::Tensor<cpu, 2> *tempspace,
+                                  mshadow::Tensor<cpu, 1> *output,
+                                  index_t *out_size) {
+  CHECK_EQ(dets.shape_[1], 5) << "dets: [x1, y1, x2, y2, score]";
+  CHECK_EQ(dets.shape_[0], tempspace->shape_[1]);
+  CHECK_GE(tempspace->shape_[0], 4);
+  CHECK_GT(dets.shape_[0], 0);
+  CHECK_EQ(dets.CheckContiguous(), true);
+  CHECK_EQ(tempspace->CheckContiguous(), true);
+  mshadow::Tensor<cpu, 1> score = (*tempspace)[0];
+  mshadow::Tensor<cpu, 1> area = (*tempspace)[1];
+  mshadow::Tensor<cpu, 1> order = (*tempspace)[2];
+  mshadow::Tensor<cpu, 1> surprised = (*tempspace)[3];
+  mshadow::Tensor<cpu, 1> keep = *output;
+  // copy score, calculate area, init order
+  for (index_t i = 0; i < dets.size(0); ++i) {
+    area[i] = (dets[i][2] - dets[i][0] + 1) *
+              (dets[i][3] - dets[i][1] + 1);
+    score[i] = dets[i][4];
+    order[i] = i;
+  }
+
+  // argsort to get order
+  ReverseArgsortCompl cmpl(score.dptr_);
+  std::sort(order.dptr_, order.dptr_ + dets.size(0), cmpl);
+
+  // calculate nms
+  *out_size = 0;
+  index_t valid_size= 0;
+  for (index_t k = 0; k < dets.size(0) && valid_size <
+       pre_nms_top_n && (*out_size) < post_nms_top_n; ++k) {
+    index_t i = static_cast<index_t>(order[k]);
+    float ix1 = dets[i][0];
+    float iy1 = dets[i][1];
+    float ix2 = dets[i][2];
+    float iy2 = dets[i][3];
+    float iarea = area[i];
+    float ih = ix2 - ix1 + 1;
+    float iw = iy2 - iy1 + 1;
+
+    if (ih < min_size || iw < min_size) {
+      valid_size++;
+      continue;
+    }
+    if (surprised[i] > 0.0f ) {
+      continue;
+    }
+
+    keep[(*out_size)++] = i;
+    for (index_t j = k + 1; j <dets.shape_[0]; ++j) {
+      index_t l = static_cast<index_t>(order[j]);
+      if (surprised[l] > 0.0f) {
+        continue;
+      }
+      float xx1 = std::max(ix1, dets[l][0]);
+      float yy1 = std::max(iy1, dets[l][1]);
+      float xx2 = std::min(ix2, dets[l][2]);
+      float yy2 = std::min(iy2, dets[l][3]);
+      float w = std::max(0.0f, xx2 - xx1 + 1);
+      float h = std::max(0.0f, yy2 - yy1 + 1);
+      float inter = w * h;
+      float ovr = inter / (iarea + area[l] - inter);
+      if (ovr > thresh ) {
+        surprised[l] = 1.0f;
+      }
+    }
+  }
+}
+
+
+
+}  // namespace utils
+}  // namespace op
+}  // namespace mxnet
+
+//========================
+// Anchor Generation Utils
+//========================
+namespace mxnet {
+namespace op {
+namespace utils {
+
+inline void _MakeAnchor(float w,
+                        float h,
+                        float x_ctr,
+                        float y_ctr,
+                        mshadow::Tensor<cpu, 1> *out_anchors) {
+  (*out_anchors)[0] = x_ctr - 0.5*(w - 1);
+  (*out_anchors)[1] = y_ctr - 0.5*(h - 1);
+  (*out_anchors)[2] = x_ctr + 0.5*(w - 1);
+  (*out_anchors)[3] = y_ctr + 0.5*(h - 1);
+}
+
+inline void _Transform(float scale,
+                       float ratio,
+                       const std::vector<float>& base_anchor,
+                       mshadow::Tensor<cpu, 1> *out_anchor) {
+  float w = base_anchor[2] - base_anchor[1] + 1;
+  float h = base_anchor[3] - base_anchor[1] + 1;
+  float x_ctr = base_anchor[0] + 0.5 * (w-1);
+  float y_ctr = base_anchor[1] + 0.5 * (h-1);
+  float size = w * h;
+  float size_ratios = std::floor(size / ratio);
+  float new_w = std::floor(std::sqrt(size_ratios) + 0.5) * scale;
+  float new_h = std::floor((new_w / scale * ratio) + 0.5) * scale;
+
+  _MakeAnchor(new_w, new_h, x_ctr,
+             y_ctr, out_anchor);
+}
+
+// out_anchors must have shape (n,4), where n is ratios.size() * scales.size()
+inline void GenerateAnchors(const std::vector<float>& base_anchor,
+                            const std::vector<float>& ratios,
+                            const std::vector<float>& scales,
+                            mshadow::Tensor<cpu, 2>* out_anchors) {
+  CHECK_GE(out_anchors->size(0), ratios.size() * scales.size());
+  CHECK_GE(out_anchors->size(1), 4);
+  size_t i = 0;
+  for (size_t j = 0; j < ratios.size(); ++j) {
+    for (size_t k = 0; k < scales.size(); ++k) {
+      mshadow::Tensor<cpu, 1> out_anchor = (*out_anchors)[i];
+      _Transform(scales[k], ratios[j], base_anchor, &out_anchor);
+      ++i;
+    }
+  }
+}
+
+}  // namespace utils
+}  // namespace op
+}  // namespace mxnet
+
+//============================
+// Bounding Box Transform Utils
+//============================
+namespace mxnet {
+namespace op {
+namespace utils {
+
+inline void BBoxTransform(const mshadow::Tensor<cpu, 2>& ex_rois,
+                   const mshadow::Tensor<cpu, 2>& gt_rois,
+                   mshadow::Tensor<cpu, 2> *out_targets) {
+  CHECK_EQ(ex_rois.size(1), 4);
+  CHECK_EQ(gt_rois.size(1), 4);
+  CHECK_EQ(out_targets->size(1), 4);
+  CHECK_EQ(ex_rois.size(0), gt_rois.size(0));
+  CHECK_EQ(gt_rois.size(0), out_targets->size(0));
+
+  size_t num_rois = ex_rois.size(0);
+
+  for (size_t i=0; i < num_rois; ++i) {
+    float ex_width = ex_rois[i][2] - ex_rois[i][0] + 1.0;
+    float ex_height = ex_rois[i][3] - ex_rois[i][1] + 1.0;
+    float ex_ctr_x = ex_rois[i][0] + 0.5 * ex_width;
+    float ex_ctr_y = ex_rois[i][1] + 0.5 * ex_height;
+
+    float gt_width = gt_rois[i][2] - gt_rois[i][0] + 1.0;
+    float gt_height = gt_rois[i][3] - gt_rois[i][1] + 1.0;
+    float gt_ctr_x = gt_rois[i][0] + 0.5 * gt_width;
+    float gt_ctr_y = gt_rois[i][1] + 0.5 * gt_height;
+
+    float target_dx = (gt_ctr_x - ex_ctr_x) / ex_width;
+    float target_dy = (gt_ctr_y - ex_ctr_y)/ ex_height;
+    float target_dw = log(gt_width) - log(ex_width);
+    float target_dh = log(gt_height) - log(ex_height);
+
+    (*out_targets)[i][0] = target_dx;
+    (*out_targets)[i][1] = target_dy;
+    (*out_targets)[i][2] = target_dw;
+    (*out_targets)[i][3] = target_dh;
+  }
+}
+
+inline void BBoxTransformInv(const mshadow::Tensor<cpu, 2>& boxes,
+                      const mshadow::Tensor<cpu, 4>& deltas,
+                      mshadow::Tensor<cpu, 2> *out_pred_boxes) {
+  CHECK_GE(boxes.size(1), 4);
+  CHECK_GE(out_pred_boxes->size(1), 4);
+  size_t anchors = deltas.size(1)/4;
+  size_t heights = deltas.size(2);
+  size_t widths = deltas.size(3);
+
+  for (size_t a = 0; a < anchors; ++a) {
+    for (size_t h = 0; h < heights; ++h) {
+      for (size_t w = 0; w < widths; ++w) {
+        index_t index = h * (widths * anchors) + w * (anchors) + a;
+        float width = boxes[index][2] - boxes[index][0] + 1.0;
+        float height = boxes[index][3] - boxes[index][1] + 1.0;
+        float ctr_x = boxes[index][0] + 0.5 * width;
+        float ctr_y = boxes[index][1] + 0.5 * height;
+
+        float dx = deltas[0][a*4 + 0][h][w];
+        float dy = deltas[0][a*4 + 1][h][w];
+        float dw = deltas[0][a*4 + 2][h][w];
+        float dh = deltas[0][a*4 + 3][h][w];
+
+        float pred_ctr_x = dx * width + ctr_x;
+        float pred_ctr_y = dy * height + ctr_y;
+        float pred_w = exp(dw) * width;
+        float pred_h = exp(dh) * height;
+
+        (*out_pred_boxes)[index][0] = pred_ctr_x - 0.5 * pred_w;
+        (*out_pred_boxes)[index][1] = pred_ctr_y - 0.5 * pred_h;
+        (*out_pred_boxes)[index][2] = pred_ctr_x + 0.5 * pred_w;
+        (*out_pred_boxes)[index][3] = pred_ctr_y + 0.5 * pred_h;
+      }
+    }
+  }
+}
+
+inline void ClipBoxes(const mshadow::Shape<2>& im_shape, mshadow::Tensor<cpu, 2> *in_out_boxes) {
+  CHECK_GE(in_out_boxes->size(1), 4);
+  size_t num_boxes = in_out_boxes->size(0);
+
+  for (size_t i=0; i < num_boxes; ++i) {
+    (*in_out_boxes)[i][0] = std::max(std::min((*in_out_boxes)[i][0],
+          static_cast<float> (im_shape[1] - 1)), static_cast<float>(0));
+    (*in_out_boxes)[i][1] = std::max(std::min((*in_out_boxes)[i][1],
+          static_cast<float> (im_shape[0] - 1)), static_cast<float>(0));
+    (*in_out_boxes)[i][2] = std::max(std::min((*in_out_boxes)[i][2],
+          static_cast <float>(im_shape[1] - 1)), static_cast<float>(0));
+    (*in_out_boxes)[i][3] = std::max(std::min((*in_out_boxes)[i][3],
+          static_cast <float>(im_shape[0] - 1)), static_cast<float>(0));
+  }
+}
+
+
+
+}  // namespace utils
+}  // namespace op
+}  // namespace mxnet
+
+
+#endif  // MXNET_OPERATOR_RCNN_UTILS_H_

--- a/src/operator/reshape-inl.h
+++ b/src/operator/reshape-inl.h
@@ -27,18 +27,6 @@ enum ReshapeOpOutputs {kOut};
 
 
 struct ShapeInfo {
-  inline size_t ndim() const {
-    return info.size();
-  }
-
-  inline size_t Size() const {
-    size_t sz = 1;
-    for (size_t i = 0; i < info.size(); ++i) {
-      sz *= info[i];
-    }
-    return sz;
-  }
-
   std::vector<int> info;
 };
 
@@ -52,18 +40,9 @@ inline std::istream &operator>>(std::istream &is, ShapeInfo &shape) {
       return is;
     }
   }
+
   int idx;
   std::vector<int> tmp;
-  // deal with empty case
-  // safe to remove after stop using target_shape
-  size_t pos = is.tellg();
-  char ch = is.get();
-  if (ch == ')') {
-    shape.info = tmp;
-    return is;
-  }
-  is.seekg(pos);
-  // finish deal
   while (is >> idx) {
     tmp.push_back(idx);
     char ch;
@@ -202,7 +181,7 @@ class ReshapeProp : public OperatorProperty {
              param_.shape.info.size() > 0, true) << "targe_shape or shape must be present.";
     const TShape &dshape = in_shape->at(reshape_enum::kData);
     if (dshape.ndim() == 0) return false;
-    if (param_.shape.ndim() != 0) {
+    if (param_.shape.info.size() != 0) {
       std::vector<int> tmp;
       int src_idx = 0;
       int neg_idx = -1;

--- a/tests/python/unittest/test_pretrained_image_classifier.py
+++ b/tests/python/unittest/test_pretrained_image_classifier.py
@@ -1,0 +1,88 @@
+import mxnet as mx
+import array
+import unittest
+import numpy as np
+
+__has_sframe__ = False
+__has_graphlab__ = False
+try:
+    import sframe as gl
+    __has_sframe__ = True
+except:
+    pass
+
+try:
+    import graphlab
+    __has_graphlab__ = True
+except:
+    pass
+
+
+@unittest.skipIf(__has_sframe__ is False and __has_graphlab__ is False, 'graphlab or sframe not found')
+class PretrainedImageClassifierTest(unittest.TestCase):
+    def setUp(self):
+        self.train = graphlab.SFrame('http://s3.amazonaws.com/dato-datasets/mnist/sframe/train') 
+        self.test = graphlab.SFrame('http://s3.amazonaws.com/dato-datasets/mnist/sframe/test') 
+        mx.pretrained_model.download_model('https://s3.amazonaws.com/dato-models/mxnet_models/release/image_classifier/mnist_lenet-1.0.tar.gz', overwrite=True)
+        self.model = mx.pretrained_model.load_model('mnist_lenet') 
+
+    def test_predict_topk(self):
+	# Test accuracy of predictions
+	preds = self.model.predict_topk(self.test, k=1)
+	test = self.test.copy()
+	test['preds'] = preds['label']
+	accuracy = graphlab.evaluation.accuracy(test['label'], test['preds'])
+	self.assertGreater(accuracy, 0.95)
+
+	# Test k > 1		
+	preds2 = self.model.predict_topk(self.test, k=5)
+	self.assertEqual(len(preds) * 5, len(preds2))	
+
+	# Test bad input
+	duplicate_image = self.test.copy()
+	duplicate_image['dup'] = duplicate_image['image']
+	with self.assertRaises(TypeError):
+            self.model.predict_topk(duplicate_image) 	
+
+	# Test bad input
+	no_image = self.test.copy()
+	del no_image['image']
+	with self.assertRaises(TypeError):
+            self.model.predict_topk(no_image) 	
+
+
+    def test_extract_features(self):
+	# Test feature quality
+	train_features = self.model.extract_feature(self.train)
+	test_features = self.model.extract_feature(self.test)
+
+	train = self.train.copy()
+	train['features'] = train_features['feature']
+	test = self.test.copy()
+	test['features'] = test_features['feature']
+
+	mdl = graphlab.logistic_classifier.create(train, features=['features'], target='label')
+	accuracy = mdl.evaluate(test)['accuracy']
+
+	self.assertGreater(accuracy, 0.95)
+	
+	# Test bad input
+	duplicate_image = self.test.copy()
+	duplicate_image['dup'] = duplicate_image['image']
+	with self.assertRaises(TypeError):
+            self.model.extract_feature(duplicate_image) 	
+
+	# Test bad input
+	no_image = self.test.copy()
+	del no_image['image']
+	with self.assertRaises(TypeError):
+            self.model.extract_feature(no_image) 	
+
+
+    def test_extract_features_alias(self):
+	features = np.concatenate(list(self.model.extract_feature(self.test)['feature']))
+	alias_features = np.concatenate(list(self.model.extract_features(self.test)['feature']))
+
+	np.testing.assert_array_almost_equal(features, alias_features)
+	
+

--- a/tests/python/unittest/test_pretrained_image_classifier.py
+++ b/tests/python/unittest/test_pretrained_image_classifier.py
@@ -34,9 +34,17 @@ class PretrainedImageClassifierTest(unittest.TestCase):
 	accuracy = graphlab.evaluation.accuracy(test['label'], test['preds'])
 	self.assertGreater(accuracy, 0.95)
 
+        # Test SArray
+	preds2 = self.model.predict_topk(self.test['image'], k=1)
+        self.assertListEqual(list(preds['label']), list(preds2['label']))
+
+        # Test Image
+	preds3 = self.model.predict_topk(self.test['image'][0], k=1)
+        self.assertEqual(preds['label'][0], preds3['label'][0])
+
 	# Test k > 1		
-	preds2 = self.model.predict_topk(self.test, k=5)
-	self.assertEqual(len(preds) * 5, len(preds2))	
+	preds4 = self.model.predict_topk(self.test, k=5)
+	self.assertEqual(len(preds) * 5, len(preds4))	
 
 	# Test bad input
 	duplicate_image = self.test.copy()
@@ -66,6 +74,15 @@ class PretrainedImageClassifierTest(unittest.TestCase):
 
 	self.assertGreater(accuracy, 0.95)
 	
+        # Test SArray
+	test_features2 = self.model.extract_feature(self.test['image'])
+	np.testing.assert_array_almost_equal(np.concatenate(list(test_features2['feature'])), np.concatenate(list(test_features['feature'])))
+	
+        # Test Image
+	test_features3 = self.model.extract_feature(self.test['image'][0])
+	np.testing.assert_array_almost_equal(np.concatenate(list(test_features3['feature'])), np.concatenate(list(test_features['feature'][0:1])))
+	
+
 	# Test bad input
 	duplicate_image = self.test.copy()
 	duplicate_image['dup'] = duplicate_image['image']


### PR DESCRIPTION
Add pretrained model module
Provide Pretrained ImageClassifier with high level APIs like:
predict_topk and extract_feature.

Provide model management APIs:
- list_models()
- download()
- load_model()

Usage:

```
In [2]: import mxnet as mx

In [3]: mx.pretrained_model.download_model('https://s3.amazonaws.com/dato-models/mxnet_models/release/image_classifier/FastNet-1.0.tar.gz', overwrite=True)

In [4]: mx.pretrained_model.list_models()
Out[4]: [ModelEntry(name=u'FastNet', type=u'IMAGE_CLASSIFIER', version=u'1.0')]

In [5]: mx.pretrained_model.download_model('https://s3.amazonaws.com/dato-models/mxnet_models/release/image_classifier/InceptionBN-1.0.tar.gz', overwrite=True)

In [6]: mx.pretrained_model.list_models()
[ModelEntry(name=u'InceptionBN', type=u'IMAGE_CLASSIFIER', version=u'1.0'),
 ModelEntry(name=u'FastNet', type=u'IMAGE_CLASSIFIER', version=u'1.0')]
```

```
fastnet = mx.pretrained_model.load_model('FastNet')
fastnet.extract_feature(...)
fastnet.predict_topk(...)
```
